### PR TITLE
Fix sending UPDATE_NEEDED notification

### DIFF
--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -328,6 +328,11 @@ class PolicyManagerImpl : public PolicyManager {
   uint32_t retry_sequence_index_;
 
   /**
+   * Timeout for current trying of retry sequence
+   */
+  uint32_t current_retry_sequence_timeout_;
+
+  /**
    * Lock for guarding retry sequence
    */
   sync_primitives::Lock retry_sequence_lock_;

--- a/src/components/policy/policy_regular/include/policy/update_status_manager.h
+++ b/src/components/policy/policy_regular/include/policy/update_status_manager.h
@@ -209,23 +209,6 @@ class UpdateStatusManager : public UpdateStatusManagerInterface {
   bool app_registered_from_non_consented_device_;
   sync_primitives::Lock apps_search_in_progress_lock_;
 
-  class UpdateThreadDelegate : public threads::ThreadDelegate {
-   public:
-    UpdateThreadDelegate(UpdateStatusManager* update_status_manager);
-    ~UpdateThreadDelegate();
-    virtual void threadMain();
-    virtual void exitThreadMain();
-    void updateTimeOut(const uint32_t timeout_ms);
-
-    volatile uint32_t timeout_;
-    volatile bool stop_flag_;
-    sync_primitives::Lock state_lock_;
-    sync_primitives::ConditionalVariable termination_condition_;
-    UpdateStatusManager* update_status_manager_;
-  };
-
-  UpdateThreadDelegate* update_status_thread_delegate_;
-  threads::Thread* thread_;
 };
 }
 

--- a/src/components/policy/policy_regular/include/policy/update_status_manager.h
+++ b/src/components/policy/policy_regular/include/policy/update_status_manager.h
@@ -83,9 +83,8 @@ class UpdateStatusManager : public UpdateStatusManagerInterface {
 
   /**
    * @brief Update status hanlder for PTS sending out
-   * @param update_timeout Timeout for waiting of incoming PTU (msec)
    */
-  void OnUpdateSentOut(uint32_t update_timeout);
+  void OnUpdateSentOut();
 
   /**
    * @brief Update status handler for PTU waiting timeout
@@ -208,7 +207,6 @@ class UpdateStatusManager : public UpdateStatusManagerInterface {
   bool apps_search_in_progress_;
   bool app_registered_from_non_consented_device_;
   sync_primitives::Lock apps_search_in_progress_lock_;
-
 };
 }
 

--- a/src/components/policy/policy_regular/include/policy/update_status_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/update_status_manager_interface.h
@@ -71,9 +71,8 @@ class UpdateStatusManagerInterface {
 
   /**
    * @brief Update status hanlder for PTS sending out
-   * @param update_timeout Timeout for waiting of incoming PTU
    */
-  virtual void OnUpdateSentOut(uint32_t update_timeout) = 0;
+  virtual void OnUpdateSentOut() = 0;
 
   /**
    * @brief Update status handler for PTU waiting timeout

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -1031,7 +1031,7 @@ void PolicyManagerImpl::RetrySequence() {
   LOG4CXX_INFO(logger_, "Start new retry sequence");
   current_retry_sequence_timeout_ = NextRetryTimeout();
 
-  LOG4CXX_INFO(
+  LOG4CXX_DEBUG(
       logger_,
       "current_retry_sequence_timeout_ = " << current_retry_sequence_timeout_);
   update_status_manager_.OnUpdateTimeoutOccurs();

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -73,6 +73,7 @@ PolicyManagerImpl::PolicyManagerImpl()
     , cache_(new CacheManager)
     , retry_sequence_timeout_(kDefaultRetryTimeoutInMSec)
     , retry_sequence_index_(0)
+    , current_retry_sequence_timeout_(0)
     , timer_retry_sequence_("Retry sequence timer",
                             new timer::TimerTaskImpl<PolicyManagerImpl>(
                                 this, &PolicyManagerImpl::RetrySequence))
@@ -313,10 +314,12 @@ void PolicyManagerImpl::StartPTExchange() {
     if (update_status_manager_.IsUpdateRequired()) {
       if (RequestPTUpdate() && !timer_retry_sequence_.is_running()) {
         // Start retry sequency
-        const int timeout_sec = NextRetryTimeout();
+        current_retry_sequence_timeout_ = NextRetryTimeout();
         LOG4CXX_DEBUG(logger_,
-                      "Start retry sequence timeout = " << timeout_sec);
-        timer_retry_sequence_.Start(timeout_sec, timer::kPeriodic);
+                      "Start retry sequence timeout = "
+                          << current_retry_sequence_timeout_);
+        timer_retry_sequence_.Start(current_retry_sequence_timeout_,
+                                    timer::kPeriodic);
       }
     }
   }
@@ -772,7 +775,7 @@ uint32_t PolicyManagerImpl::NextRetryTimeout() {
   LOG4CXX_DEBUG(logger_, "Index: " << retry_sequence_index_);
   uint32_t next = 0u;
   if (retry_sequence_seconds_.empty() ||
-      retry_sequence_index_ >= retry_sequence_seconds_.size()) {
+      retry_sequence_index_ > retry_sequence_seconds_.size()) {
     return next;
   }
 
@@ -820,7 +823,12 @@ void PolicyManagerImpl::OnExceededTimeout() {
 }
 
 void PolicyManagerImpl::OnUpdateStarted() {
-  uint32_t update_timeout = TimeoutExchangeMSec();
+  uint32_t update_timeout = 0;
+  if (0 == current_retry_sequence_timeout_) {
+    update_timeout = TimeoutExchangeMSec();
+  } else {
+    update_timeout = current_retry_sequence_timeout_;
+  }
   LOG4CXX_DEBUG(logger_,
                 "Update timeout will be set to (milisec): " << update_timeout);
   update_status_manager_.OnUpdateSentOut(update_timeout);
@@ -1029,15 +1037,19 @@ void PolicyManagerImpl::set_cache_manager(
 
 void PolicyManagerImpl::RetrySequence() {
   LOG4CXX_INFO(logger_, "Start new retry sequence");
-  RequestPTUpdate();
+  current_retry_sequence_timeout_ = NextRetryTimeout();
 
-  uint32_t timeout = NextRetryTimeout();
-
-  if (!timeout && timer_retry_sequence_.is_running()) {
+  LOG4CXX_INFO(
+      logger_,
+      "current_retry_sequence_timeout_ = " << current_retry_sequence_timeout_);
+  update_status_manager_.OnUpdateTimeoutOccurs();
+  if (!current_retry_sequence_timeout_ && timer_retry_sequence_.is_running()) {
     timer_retry_sequence_.Stop();
     return;
   }
-  timer_retry_sequence_.Start(timeout, timer::kPeriodic);
+  RequestPTUpdate();
+  timer_retry_sequence_.Start(current_retry_sequence_timeout_,
+                              timer::kPeriodic);
 }
 
 }  //  namespace policy

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -823,15 +823,7 @@ void PolicyManagerImpl::OnExceededTimeout() {
 }
 
 void PolicyManagerImpl::OnUpdateStarted() {
-  uint32_t update_timeout = 0;
-  if (0 == current_retry_sequence_timeout_) {
-    update_timeout = TimeoutExchangeMSec();
-  } else {
-    update_timeout = current_retry_sequence_timeout_;
-  }
-  LOG4CXX_DEBUG(logger_,
-                "Update timeout will be set to (milisec): " << update_timeout);
-  update_status_manager_.OnUpdateSentOut(update_timeout);
+  update_status_manager_.OnUpdateSentOut();
   cache_->SaveUpdateRequired(true);
 }
 

--- a/src/components/policy/policy_regular/src/update_status_manager.cc
+++ b/src/components/policy/policy_regular/src/update_status_manager.cc
@@ -44,19 +44,10 @@ UpdateStatusManager::UpdateStatusManager()
     , current_status_(utils::MakeShared<UpToDateStatus>())
     , apps_search_in_progress_(false)
     , app_registered_from_non_consented_device_(true) {
-  update_status_thread_delegate_ = new UpdateThreadDelegate(this);
-  thread_ = threads::CreateThread("UpdateStatusThread",
-                                  update_status_thread_delegate_);
-  thread_->start();
 }
 
 UpdateStatusManager::~UpdateStatusManager() {
   LOG4CXX_AUTO_TRACE(logger_);
-  DCHECK(update_status_thread_delegate_);
-  DCHECK(thread_);
-  thread_->join();
-  delete update_status_thread_delegate_;
-  threads::DeleteThread(thread_);
 }
 
 void UpdateStatusManager::ProcessEvent(UpdateEvent event) {
@@ -79,27 +70,22 @@ void UpdateStatusManager::set_listener(PolicyListener* listener) {
 
 void UpdateStatusManager::OnUpdateSentOut(uint32_t update_timeout) {
   LOG4CXX_AUTO_TRACE(logger_);
-  DCHECK(update_status_thread_delegate_);
-  update_status_thread_delegate_->updateTimeOut(update_timeout);
+  UNUSED(update_timeout);
   ProcessEvent(kOnUpdateSentOut);
 }
 
 void UpdateStatusManager::OnUpdateTimeoutOccurs() {
   LOG4CXX_AUTO_TRACE(logger_);
   ProcessEvent(kOnUpdateTimeout);
-  DCHECK(update_status_thread_delegate_);
-  update_status_thread_delegate_->updateTimeOut(0);  // Stop Timer
 }
 
 void UpdateStatusManager::OnValidUpdateReceived() {
   LOG4CXX_AUTO_TRACE(logger_);
-  update_status_thread_delegate_->updateTimeOut(0);  // Stop Timer
   ProcessEvent(kOnValidUpdateReceived);
 }
 
 void UpdateStatusManager::OnWrongUpdateReceived() {
   LOG4CXX_AUTO_TRACE(logger_);
-  update_status_thread_delegate_->updateTimeOut(0);  // Stop Timer
   ProcessEvent(kOnWrongUpdateReceived);
 }
 
@@ -193,59 +179,6 @@ void UpdateStatusManager::DoTransition() {
   current_status_ = postponed_status_;
   listener_->OnUpdateStatusChanged(current_status_->get_status_string());
   postponed_status_.reset();
-}
-
-UpdateStatusManager::UpdateThreadDelegate::UpdateThreadDelegate(
-    UpdateStatusManager* update_status_manager)
-    : timeout_(0)
-    , stop_flag_(false)
-    , state_lock_(true)
-    , update_status_manager_(update_status_manager) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  LOG4CXX_DEBUG(logger_, "Create UpdateThreadDelegate");
-}
-
-UpdateStatusManager::UpdateThreadDelegate::~UpdateThreadDelegate() {
-  LOG4CXX_AUTO_TRACE(logger_);
-  LOG4CXX_DEBUG(logger_, "Delete UpdateThreadDelegate");
-}
-
-void UpdateStatusManager::UpdateThreadDelegate::threadMain() {
-  LOG4CXX_AUTO_TRACE(logger_);
-  LOG4CXX_DEBUG(logger_, "UpdateStatusManager thread started (started normal)");
-  sync_primitives::AutoLock auto_lock(state_lock_);
-  while (false == stop_flag_) {
-    if (timeout_ > 0) {
-      LOG4CXX_DEBUG(logger_, "Timeout is greater then 0");
-      sync_primitives::ConditionalVariable::WaitStatus wait_status =
-          termination_condition_.WaitFor(auto_lock, timeout_);
-      if (sync_primitives::ConditionalVariable::kTimeout == wait_status) {
-        if (update_status_manager_) {
-          update_status_manager_->OnUpdateTimeoutOccurs();
-        }
-      }
-    } else {
-      // Time is not active, wait until timeout will be set,
-      // or UpdateStatusManager will be deleted
-      termination_condition_.Wait(auto_lock);
-    }
-  }
-}
-
-void UpdateStatusManager::UpdateThreadDelegate::exitThreadMain() {
-  LOG4CXX_AUTO_TRACE(logger_);
-  sync_primitives::AutoLock auto_lock(state_lock_);
-  stop_flag_ = true;
-  LOG4CXX_DEBUG(logger_, "before notify");
-  termination_condition_.NotifyOne();
-}
-
-void UpdateStatusManager::UpdateThreadDelegate::updateTimeOut(
-    const uint32_t timeout_ms) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  sync_primitives::AutoLock auto_lock(state_lock_);
-  timeout_ = timeout_ms;
-  termination_condition_.NotifyOne();
 }
 
 }  // namespace policy

--- a/src/components/policy/policy_regular/src/update_status_manager.cc
+++ b/src/components/policy/policy_regular/src/update_status_manager.cc
@@ -43,8 +43,7 @@ UpdateStatusManager::UpdateStatusManager()
     : listener_(NULL)
     , current_status_(utils::MakeShared<UpToDateStatus>())
     , apps_search_in_progress_(false)
-    , app_registered_from_non_consented_device_(true) {
-}
+    , app_registered_from_non_consented_device_(true) {}
 
 UpdateStatusManager::~UpdateStatusManager() {
   LOG4CXX_AUTO_TRACE(logger_);
@@ -68,9 +67,8 @@ void UpdateStatusManager::set_listener(PolicyListener* listener) {
   listener_ = listener;
 }
 
-void UpdateStatusManager::OnUpdateSentOut(uint32_t update_timeout) {
+void UpdateStatusManager::OnUpdateSentOut() {
   LOG4CXX_AUTO_TRACE(logger_);
-  UNUSED(update_timeout);
   ProcessEvent(kOnUpdateSentOut);
 }
 

--- a/src/components/policy/policy_regular/test/include/policy/mock_update_status_manager.h
+++ b/src/components/policy/policy_regular/test/include/policy/mock_update_status_manager.h
@@ -41,7 +41,7 @@ namespace policy {
 class MockUpdateStatusManager : public UpdateStatusManager {
  public:
   MOCK_METHOD1(set_listener, void(PolicyListener* listener));
-  MOCK_METHOD1(OnUpdateSentOut, void(uint32_t update_timeout));
+  MOCK_METHOD0(OnUpdateSentOut, void());
   MOCK_METHOD0(OnUpdateTimeoutOccurs, void());
   MOCK_METHOD0(OnValidUpdateReceived, void());
   MOCK_METHOD0(OnWrongUpdateReceived, void());

--- a/src/components/policy/policy_regular/test/update_status_manager_test.cc
+++ b/src/components/policy/policy_regular/test/update_status_manager_test.cc
@@ -73,7 +73,7 @@ TEST_F(UpdateStatusManagerTest,
   manager_->OnPolicyInit(true);
   // Check
   EXPECT_EQ("UPDATE_NEEDED", manager_->StringifiedUpdateStatus());
-  manager_->OnUpdateSentOut(k_timeout_);
+  manager_->OnUpdateSentOut();
   // Check
   EXPECT_EQ("UPDATING", manager_->StringifiedUpdateStatus());
 }


### PR DESCRIPTION
The same PR on develop [#1542](https://github.com/smartdevicelink/sdl_core/pull/1542)

After clarification UPDATE_NEEDED should be sent after retry sequence timeout, not after fixed timeout.
For this purpose there was removed thread for update status manager.