### PR TITLE
Fix OnTimeout event handling for CAN module

### DIFF
--- a/src/components/can_cooperation/src/can_module.cc
+++ b/src/components/can_cooperation/src/can_module.cc
@@ -367,6 +367,9 @@ void CANModule::SendResponseToMobile(application_manager::MessagePtr msg) {
 
 void CANModule::SendTimeoutResponseToMobile(
     application_manager::MessagePtr msg) {
+  LOG4CXX_DEBUG(
+      logger_,
+      "Timeout is expired. Response to mobile: " << msg->json_message());
   service()->SendMessageToMobile(msg);
 }
 

--- a/src/components/can_cooperation/src/commands/base_command_request.cc
+++ b/src/components/can_cooperation/src/commands/base_command_request.cc
@@ -75,7 +75,9 @@ void BaseCommandRequest::SendResponse(bool success,
   }
 
   msg_params[kSuccess] = success;
-  msg_params[kResultCode] = result_code;
+  const bool is_timeout = (0 == strcmp(result_code, result_codes::kTimedOut));
+  msg_params[kResultCode] =
+      is_timeout ? result_codes::kGenericError : result_code;
   if (!info.empty()) {
     msg_params[kInfo] = info;
   }
@@ -83,7 +85,7 @@ void BaseCommandRequest::SendResponse(bool success,
   Json::FastWriter writer;
   std::string params = writer.write(msg_params);
   message_->set_json_message(params);
-  if (0 == strcmp(result_code, result_codes::kTimedOut)) {
+  if (is_timeout) {
     can_module_.SendTimeoutResponseToMobile(message_);
   } else {
     can_module_.SendResponseToMobile(message_);

--- a/src/components/can_cooperation/src/request_controller.cc
+++ b/src/components/can_cooperation/src/request_controller.cc
@@ -60,18 +60,26 @@ void RequestController::AddRequest(const uint32_t mobile_correlation_id,
                                    MobileRequestPtr request) {
   // TODO(VS) Research and fix be problem with overlap correlation ids from two
   // different apllications(on two different mobile devices)
+  LOG4CXX_DEBUG(logger_, "Add request with correlation_id: "
+                << mobile_correlation_id);
   mobile_request_list_[mobile_correlation_id] = request;
   // TODO(VS): add app id
   timer_.AddTrackable(TrackableMessage(0, mobile_correlation_id));
+  time_director_.ResetTimer(timer_);
 }
 
 void RequestController::DeleteRequest(const uint32_t& mobile_correlation_id) {
+  LOG4CXX_DEBUG(logger_, "Delete request with correlation_id: "
+                << mobile_correlation_id);
   mobile_request_list_.erase(mobile_correlation_id);
   // TODO(VS): add app id
   timer_.RemoveTrackable(TrackableMessage(0, mobile_correlation_id));
 }
 
 void RequestController::OnTimeoutTriggered(const TrackableMessage& expired) {
+  LOG4CXX_DEBUG(logger_,
+                "Timeout is expired for request with correlation_id: "
+                    << expired.correlation_id());
   std::map<correlation_id, MobileRequestPtr>::iterator it =
       mobile_request_list_.find(expired.correlation_id());
   if (mobile_request_list_.end() == it) {

--- a/src/components/can_cooperation/src/request_controller.cc
+++ b/src/components/can_cooperation/src/request_controller.cc
@@ -60,8 +60,8 @@ void RequestController::AddRequest(const uint32_t mobile_correlation_id,
                                    MobileRequestPtr request) {
   // TODO(VS) Research and fix be problem with overlap correlation ids from two
   // different apllications(on two different mobile devices)
-  LOG4CXX_DEBUG(logger_, "Add request with correlation_id: "
-                << mobile_correlation_id);
+  LOG4CXX_DEBUG(logger_,
+                "Add request with correlation_id: " << mobile_correlation_id);
   mobile_request_list_[mobile_correlation_id] = request;
   // TODO(VS): add app id
   timer_.AddTrackable(TrackableMessage(0, mobile_correlation_id));
@@ -69,8 +69,8 @@ void RequestController::AddRequest(const uint32_t mobile_correlation_id,
 }
 
 void RequestController::DeleteRequest(const uint32_t& mobile_correlation_id) {
-  LOG4CXX_DEBUG(logger_, "Delete request with correlation_id: "
-                << mobile_correlation_id);
+  LOG4CXX_DEBUG(
+      logger_, "Delete request with correlation_id: " << mobile_correlation_id);
   mobile_request_list_.erase(mobile_correlation_id);
   // TODO(VS): add app id
   timer_.RemoveTrackable(TrackableMessage(0, mobile_correlation_id));

--- a/src/components/functional_module/include/functional_module/timer/module_timer.h
+++ b/src/components/functional_module/include/functional_module/timer/module_timer.h
@@ -78,7 +78,7 @@ class ModuleTimer {
   }
   TimeUnit period() const {
     return period_;
-  }  
+  }
   void AddObserver(TimerObserver<Trackable>* observer);
   void RemoveObserver(TimerObserver<Trackable>* observer);
 

--- a/src/components/functional_module/include/functional_module/timer/module_timer.h
+++ b/src/components/functional_module/include/functional_module/timer/module_timer.h
@@ -78,11 +78,17 @@ class ModuleTimer {
   }
   TimeUnit period() const {
     return period_;
-  }
+  }  
   void AddObserver(TimerObserver<Trackable>* observer);
   void RemoveObserver(TimerObserver<Trackable>* observer);
 
   void CheckTimeout();
+  /**
+   * @brief Gets time in seconds when the nearest request timeout will be
+   * triggered
+   * @return time in seconds when the nearest request timeout will be triggered
+   */
+  TimeUnit GetSecondsToNearestTimeout();
 
   /*
    * @brief Adds object to be tracked by timer.
@@ -158,6 +164,26 @@ void ModuleTimer<Trackable>::CheckTimeout() {
       it = trackables_.erase(it);
     }
   }
+}
+
+template <class Trackable>
+TimeUnit ModuleTimer<Trackable>::GetSecondsToNearestTimeout() {
+  sync_primitives::AutoLock trackables_lock(trackables_lock_);
+  TimeUnit result = period_;
+  for (typename std::list<Trackable>::iterator it = trackables_.begin();
+       trackables_.end() != it;
+       ++it) {
+    TimeUnit period = it->custom_interval();
+    if (!period) {
+      period = period_;
+    }
+    const TimeUnit current_secs_to_timeout =
+        period - (CurrentTime() - it->start_time());
+    if (result > current_secs_to_timeout) {
+      result = current_secs_to_timeout;
+    }
+  }
+  return result;
 }
 
 template <class Trackable>

--- a/src/components/functional_module/include/functional_module/timer/timer_director.h
+++ b/src/components/functional_module/include/functional_module/timer/timer_director.h
@@ -47,6 +47,11 @@ class TimerThreadDelegate : public threads::ThreadDelegate {
   void threadMain();
   void exitThreadMain();
 
+  /**
+   * @brief Reset awaiting timer by notifying cond var
+   */
+  void ResetTimer();
+
  private:
   ModuleTimer<T>& timer_;
   volatile bool keep_running_;
@@ -70,6 +75,12 @@ class TimerDirector {
   template <class T>
   void UnregisterTimer(const ModuleTimer<T>& timer);
   void UnregisterAllTimers();
+  /**
+   * @brief Reset awaiting timeout for specified module timer
+   * @param timer timer to reset awaiting timeout
+   */
+  template <class T>
+  void ResetTimer(ModuleTimer<T>& timer);
 
  private:
   DISALLOW_COPY_AND_ASSIGN(TimerDirector);

--- a/src/components/functional_module/src/timer/timer_director.cc
+++ b/src/components/functional_module/src/timer/timer_director.cc
@@ -129,7 +129,7 @@ template <class T>
 void TimerDirector::ResetTimer(ModuleTimer<T>& timer) {
   const std::string type_name = typeid(timer).name();
   std::map<std::string, threads::Thread*>::iterator it =
-     timer_threads_.find(type_name);
+      timer_threads_.find(type_name);
   if (timer_threads_.end() == it) {
     return;
   }

--- a/src/components/functional_module/src/timer/timer_director.cc
+++ b/src/components/functional_module/src/timer/timer_director.cc
@@ -51,9 +51,9 @@ void TimerThreadDelegate<T>::threadMain() {
   }
   sync_primitives::AutoLock run_lock(keep_running_lock_);
   while (keep_running_) {
-    const size_t kMilisecsC = 1000;
+    const TimeUnit msecs_to_wait = timer_.GetSecondsToNearestTimeout() * 1000;
     sync_primitives::ConditionalVariable::WaitStatus wait_status =
-        keep_running_cond_.WaitFor(run_lock, timer_.period() * kMilisecsC);
+        keep_running_cond_.WaitFor(run_lock, msecs_to_wait);
     if (sync_primitives::ConditionalVariable::kTimeout == wait_status &&
         keep_running_) {
       timer_.CheckTimeout();
@@ -66,6 +66,14 @@ void TimerThreadDelegate<T>::exitThreadMain() {
   if (keep_running_) {
     sync_primitives::AutoLock run_lock(keep_running_lock_);
     keep_running_ = false;
+    keep_running_cond_.NotifyOne();
+  }
+}
+
+template <class T>
+void TimerThreadDelegate<T>::ResetTimer() {
+  if (keep_running_) {
+    sync_primitives::AutoLock run_lock(keep_running_lock_);
     keep_running_cond_.NotifyOne();
   }
 }
@@ -116,6 +124,22 @@ void TimerDirector::UnregisterTimer(const ModuleTimer<T>& timer) {
 
 template void TimerDirector::UnregisterTimer<can_cooperation::TrackableMessage>(
     const ModuleTimer<can_cooperation::TrackableMessage>& timer);
+
+template <class T>
+void TimerDirector::ResetTimer(ModuleTimer<T>& timer) {
+  const std::string type_name = typeid(timer).name();
+  std::map<std::string, threads::Thread*>::iterator it =
+     timer_threads_.find(type_name);
+  if (timer_threads_.end() == it) {
+    return;
+  }
+  TimerThreadDelegate<T>* delegate =
+      static_cast<TimerThreadDelegate<T>*>(it->second->delegate());
+  delegate->ResetTimer();
+}
+
+template void TimerDirector::ResetTimer<can_cooperation::TrackableMessage>(
+    ModuleTimer<can_cooperation::TrackableMessage>& timer);
 
 void TimerDirector::UnregisterAllTimers() {
   for (std::map<std::string, threads::Thread*>::iterator it =


### PR DESCRIPTION
The problem is that `TimerDirector`'s timer checks for every request timeout every 10 seconds and not depends on time when request was sent. For example `TimeDirector` timer check all request for timeouts on 10, 20, 30 second. But if request was sent on 12th second, then default timeout for it will be on 22th second. However this timer will detect timeout and send response only on 30 second.
Also `OnTimeout` event provides wrong result code `TIMED_OUT` instead of `GENERIC_ERROR`.

In this pull request:
- Added more logs to see request controller actions
- Fixed result code for timeout event according to requirements
- Added `GetSecondsToNearestTimeout()` function to return time to the nearest request timeout or default timeout if no requests in queue. This is a correct time to wait before checking timeout. Also this function checks for custom RPC timeouts if present.
- Added `ResetTimer()` function to recalculate timers awaiting time after new request was added to queue
