### PR TITLE
Fix GetInteriorVehicleDataCapabilities parameters validation

### DIFF
--- a/src/components/can_cooperation/include/can_cooperation/commands/get_interior_vehicle_data_capabilities_request.h
+++ b/src/components/can_cooperation/include/can_cooperation/commands/get_interior_vehicle_data_capabilities_request.h
@@ -81,9 +81,9 @@ class GetInteriorVehicleDataCapabiliesRequest : public BaseCommandRequest {
  private:
   void UpdateModules(Json::Value* params);
   application_manager::TypeAccess CheckModuleTypes(const Json::Value& message);
-  bool ReadCapabilitiesFromFile();
-  void CreateCapabilities(const Json::Value& zone_capabilities,
-                          const Json::Value& modules);
+  bool ReadCapabilitiesFromFile(
+      const can_event_engine::Event<application_manager::MessagePtr,
+                                    std::string>& event);
   inline bool IsDriverDevice();
   application_manager::TypeAccess GetModuleTypes();
   application_manager::TypeAccess ProcessRequestedModuleTypes(

--- a/src/components/can_cooperation/include/can_cooperation/vehicle_capabilities.h
+++ b/src/components/can_cooperation/include/can_cooperation/vehicle_capabilities.h
@@ -61,6 +61,8 @@ class VehicleCapabilities {
    */
   Json::Value capabilities() const;
 
+  std::string default_capabilities_path();
+
  private:
   Json::Value capabilities_;
   const std::string kDefaultPath_;

--- a/src/components/can_cooperation/src/vehicle_capabilities.cc
+++ b/src/components/can_cooperation/src/vehicle_capabilities.cc
@@ -66,10 +66,15 @@ VehicleCapabilities::VehicleCapabilities()
 }
 
 Json::Value VehicleCapabilities::capabilities() const {
+  LOG4CXX_AUTO_TRACE(logger_);
   if (capabilities_.type() == Json::ValueType::objectValue) {
     return capabilities_[kInteriorVehicleDataCapabilities];
   }
   return capabilities_;
+}
+
+std::string VehicleCapabilities::default_capabilities_path() {
+  return kDefaultPath_;
 }
 
 }  // namespace can_cooperation


### PR DESCRIPTION
- Fixed parameters validation in HMI response
- Fixed parameters validation read from default caps file
- All validation proceeded via SmartObject schema validation