### PR TITLE
Fix subscription handling in GetInteriorVehicleData RPC

### DIFF
--- a/src/components/can_cooperation/include/can_cooperation/commands/get_interior_vehicle_data_request.h
+++ b/src/components/can_cooperation/include/can_cooperation/commands/get_interior_vehicle_data_request.h
@@ -75,7 +75,7 @@ class GetInteriorVehicleDataRequest : public BaseCommandRequest {
     * @brief Handle subscription to vehicle data
     *
     */
-  void ProccessSubscription(Json::Value& hmi_response);
+  void ProccessSubscription(const Json::Value& hmi_response);
 };
 
 }  // namespace commands


### PR DESCRIPTION
- Added cases when no subscription present in mobile request & hmi response
- Subscription now is proceeded if positive response from hmi received