### PR TITLE
Fix cases for GENERIC_ERROR result

### DIFF
--- a/src/components/can_cooperation/include/can_cooperation/commands/get_interior_vehicle_data_request.h
+++ b/src/components/can_cooperation/include/can_cooperation/commands/get_interior_vehicle_data_request.h
@@ -73,9 +73,16 @@ class GetInteriorVehicleDataRequest : public BaseCommandRequest {
  private:
   /**
     * @brief Handle subscription to vehicle data
-    *
+    * @param hmi_response json message with response from HMI
     */
   void ProccessSubscription(const Json::Value& hmi_response);
+
+  /**
+   * @brief Check is all requested IV data present in response
+   * @param hmi_response json message with response from HMI
+   * @return true if all requested IV data is present in reponse false otherwise
+   */
+  bool CheckForRequestedData(const Json::Value& hmi_response);
 };
 
 }  // namespace commands


### PR DESCRIPTION
This result code should be send when SDL receives invalid response message from HMI or when valid message does not contain requested control data in response. Otherwise SDL will transfer result code
and params from HMI.

Following changes were done:
- Added `CheckForRequestedData()` function to check requested control data in response
- Updated description for existing functions
- Updated logic for handling all `GENERIC_ERROR` cases