### PR TITLE
Feature/set interior vehicle data

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1258,7 +1258,8 @@ class ApplicationManagerImpl
   bool ConvertSOtoMessage(const smart_objects::SmartObject& message,
                           Message& output);
 
-  bool ValidateMessageBySchema(const Message& message) OVERRIDE;
+  MessageValidationResult ValidateMessageBySchema(
+      const Message& message) OVERRIDE;
 
   utils::SharedPtr<Message> ConvertRawMsgToMessage(
       const ::protocol_handler::RawMessagePtr message);

--- a/src/components/application_manager/include/application_manager/core_service.h
+++ b/src/components/application_manager/include/application_manager/core_service.h
@@ -221,7 +221,8 @@ class CoreService : public Service {
   bool GetModuleTypes(const std::string& policy_app_id,
                       std::vector<std::string>* modules) const FINAL;
 
-  bool ValidateMessageBySchema(const Message& message) OVERRIDE;
+  MessageValidationResult ValidateMessageBySchema(
+      const Message& message) OVERRIDE;
 
  private:
   bool AreParametersAllowed(MessagePtr msg,

--- a/src/components/application_manager/include/application_manager/service.h
+++ b/src/components/application_manager/include/application_manager/service.h
@@ -43,6 +43,14 @@ namespace application_manager {
 
 enum TypeAccess { kNone, kDisallowed, kAllowed, kManual };
 
+enum MessageValidationResult {
+  SUCCESS,
+  INVALID_JSON,
+  INVALID_METADATA,
+  SCHEMA_MISMATCH,
+  UNSUPPORTED_PROTOCOL
+};
+
 typedef std::string PluginFunctionID;
 
 /**
@@ -218,7 +226,8 @@ class Service {
    * @param message message for validation
    * @return true if message is valid according to schema, otherwise false
    */
-  virtual bool ValidateMessageBySchema(const Message& message) = 0;
+  virtual MessageValidationResult ValidateMessageBySchema(
+      const Message& message) = 0;
 };
 
 typedef utils::SharedPtr<Service> ServicePtr;

--- a/src/components/application_manager/src/core_service.cc
+++ b/src/components/application_manager/src/core_service.cc
@@ -290,7 +290,8 @@ bool CoreService::GetModuleTypes(const std::string& policy_app_id,
   return false;
 }
 
-bool CoreService::ValidateMessageBySchema(const Message& message) {
+MessageValidationResult CoreService::ValidateMessageBySchema(
+    const Message& message) {
   return application_manager_.ValidateMessageBySchema(message);
 }
 

--- a/src/components/can_cooperation/include/can_cooperation/commands/get_interior_vehicle_data_request.h
+++ b/src/components/can_cooperation/include/can_cooperation/commands/get_interior_vehicle_data_request.h
@@ -76,13 +76,6 @@ class GetInteriorVehicleDataRequest : public BaseCommandRequest {
     * @param hmi_response json message with response from HMI
     */
   void ProccessSubscription(const Json::Value& hmi_response);
-
-  /**
-   * @brief Check is all requested IV data present in response
-   * @param hmi_response json message with response from HMI
-   * @return true if all requested IV data is present in reponse false otherwise
-   */
-  bool CheckForRequestedData(const Json::Value& hmi_response);
 };
 
 }  // namespace commands

--- a/src/components/can_cooperation/include/can_cooperation/commands/set_interior_vehicle_data_request.h
+++ b/src/components/can_cooperation/include/can_cooperation/commands/set_interior_vehicle_data_request.h
@@ -1,0 +1,86 @@
+/*
+ Copyright (c) 2017, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_CAN_COOPERATION_INCLUDE_CAN_COOPERATION_COMMANDS_SET_INTERIOR_VEHICLE_DATA_REQUEST_H_
+#define SRC_COMPONENTS_CAN_COOPERATION_INCLUDE_CAN_COOPERATION_COMMANDS_SET_INTERIOR_VEHICLE_DATA_REQUEST_H_
+
+#include "can_cooperation/commands/base_command_request.h"
+#include "can_cooperation/event_engine/event.h"
+#include "utils/macro.h"
+
+namespace can_cooperation {
+
+namespace commands {
+
+/**
+ * @brief SetInteriorVehicleDataRequest command class
+ */
+class SetInteriorVehicleDataRequest : public BaseCommandRequest {
+ public:
+  /**
+   * @brief SetInteriorVehicleDataRequest class constructor
+   *
+   * @param message Message from mobile
+   * @param can_module Module used for handling RC functionality
+   **/
+  SetInteriorVehicleDataRequest(const application_manager::MessagePtr& message,
+                                CANModuleInterface& can_module);
+
+  /**
+   * @brief Execute command
+   */
+  void Execute() FINAL;
+
+  /**
+   * @brief Interface method that is called whenever new event received
+   *
+   * @param event The received event
+   */
+  void OnEvent(const can_event_engine::Event<application_manager::MessagePtr,
+                                             std::string>& event);
+
+  /**
+   * @brief SetInteriorVehicleDataRequest class destructor
+   */
+  virtual ~SetInteriorVehicleDataRequest();
+
+ protected:
+  virtual std::string ModuleType(const Json::Value& message) FINAL;
+  virtual std::vector<std::string> ControlData(
+      const Json::Value& message) FINAL;
+};
+
+}  // namespace commands
+
+}  // namespace can_cooperation
+
+#endif  // SRC_COMPONENTS_CAN_COOPERATION_INCLUDE_CAN_COOPERATION_COMMANDS_SET_INTERIOR_VEHICLE_DATA_REQUEST_H_

--- a/src/components/can_cooperation/src/can_module.cc
+++ b/src/components/can_cooperation/src/can_module.cc
@@ -113,8 +113,11 @@ ProcessResult CANModule::ProcessMessage(application_manager::MessagePtr msg) {
     return ProcessResult::FAILED;
   }
 
-  msg->set_function_name(MessageHelper::GetMobileAPIName(
-      static_cast<functional_modules::MobileFunctionID>(msg->function_id())));
+  const std::string& function_name = MessageHelper::GetMobileAPIName(
+      static_cast<functional_modules::MobileFunctionID>(msg->function_id()));
+
+  LOG4CXX_DEBUG(logger_, "Function name to set : " << function_name);
+  msg->set_function_name(function_name);
 
   LOG4CXX_DEBUG(logger_, "Mobile message: " << msg->json_message());
 

--- a/src/components/can_cooperation/src/commands/base_command_request.cc
+++ b/src/components/can_cooperation/src/commands/base_command_request.cc
@@ -135,7 +135,8 @@ void BaseCommandRequest::SendRequest(const char* function_id,
 }
 
 bool BaseCommandRequest::Validate() {
-  return service()->ValidateMessageBySchema(*message_);
+  return application_manager::SUCCESS ==
+         service()->ValidateMessageBySchema(*message_);
 }
 
 bool BaseCommandRequest::ParseJsonString(Json::Value* parsed_msg) {
@@ -318,6 +319,8 @@ void BaseCommandRequest::Run() {
     if (CheckPolicyPermissions() && CheckDriverConsent()) {
       Execute();  // run child's logic
     }
+  } else {
+    SendResponse(false, result_codes::kInvalidData, "");
   }
 }
 

--- a/src/components/can_cooperation/src/commands/set_interior_vehicle_data_request.cc
+++ b/src/components/can_cooperation/src/commands/set_interior_vehicle_data_request.cc
@@ -1,0 +1,138 @@
+/*
+ Copyright (c) 2017, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "can_cooperation/commands/set_interior_vehicle_data_request.h"
+#include <algorithm>
+#include "can_cooperation/can_module_constants.h"
+#include "can_cooperation/message_helper.h"
+#include "functional_module/function_ids.h"
+#include "json/json.h"
+
+namespace can_cooperation {
+
+namespace commands {
+
+using namespace json_keys;
+using namespace message_params;
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "SetInteriorVehicleDataRequest")
+
+SetInteriorVehicleDataRequest::SetInteriorVehicleDataRequest(
+    const application_manager::MessagePtr& message,
+    CANModuleInterface& can_module)
+    : BaseCommandRequest(message, can_module) {}
+
+SetInteriorVehicleDataRequest::~SetInteriorVehicleDataRequest() {}
+
+void SetInteriorVehicleDataRequest::Execute() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const Json::Value request_params =
+      MessageHelper::StringToValue(message_->json_message());
+  const Json::Value module_data = request_params[kModuleData];
+  const std::string module_type = module_data[kModuleType].asString();
+  bool module_type_and_data_match = true;
+
+  if (enums_value::kRadio == module_type) {
+    module_type_and_data_match = !IsMember(module_data, kClimateControlData);
+  }
+
+  if (enums_value::kClimate == module_type) {
+    module_type_and_data_match = !IsMember(module_data, kRadioControlData);
+  }
+
+  if (module_type_and_data_match) {
+    SendRequest(functional_modules::hmi_api::set_interior_vehicle_data,
+                request_params,
+                true);
+  } else {
+    LOG4CXX_WARN(logger_, "Request module type & data mismatch!");
+    SendResponse(false,
+                 result_codes::kInvalidData,
+                 "Request module type & data mismatch!");
+  }
+}
+
+void SetInteriorVehicleDataRequest::OnEvent(
+    const can_event_engine::Event<application_manager::MessagePtr, std::string>&
+        event) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  DCHECK_OR_RETURN_VOID(
+      (functional_modules::hmi_api::set_interior_vehicle_data == event.id()));
+
+  application_manager::Message& hmi_response = *(event.event_message());
+  const bool validate_result = application_manager::SUCCESS ==
+                               service()->ValidateMessageBySchema(hmi_response);
+  LOG4CXX_DEBUG(logger_,
+                "HMI response validation result is " << validate_result);
+  const Json::Value value =
+      MessageHelper::StringToValue(hmi_response.json_message());
+
+  std::string result_code;
+  std::string info;
+
+  const bool is_response_successful = ParseResultCode(value, result_code, info);
+
+  if (is_response_successful) {
+    response_params_[kModuleData] = value[kResult][kModuleData];
+  }
+  SendResponse(is_response_successful, result_code.c_str(), info);
+}
+
+std::string SetInteriorVehicleDataRequest::ModuleType(
+    const Json::Value& message) {
+  return message.get(message_params::kModuleData,
+                     Json::Value(Json::objectValue))
+      .get(message_params::kModuleType, Json::Value(""))
+      .asString();
+}
+
+std::vector<std::string> SetInteriorVehicleDataRequest::ControlData(
+    const Json::Value& message) {
+  Json::Value data =
+      message.get(message_params::kModuleData, Json::Value(Json::objectValue));
+  const char* name_control_data;
+  std::string module = ModuleType(message);
+  if (module == enums_value::kRadio) {
+    name_control_data = message_params::kRadioControlData;
+  }
+  if (module == enums_value::kClimate) {
+    name_control_data = message_params::kClimateControlData;
+  }
+  Json::Value params =
+      data.get(name_control_data, Json::Value(Json::objectValue));
+  return params.getMemberNames();
+}
+
+}  // namespace commands
+
+}  // namespace can_cooperation

--- a/src/components/can_cooperation/src/mobile_command_factory.cc
+++ b/src/components/can_cooperation/src/mobile_command_factory.cc
@@ -35,10 +35,10 @@
 #include "can_cooperation/mobile_command_factory.h"
 #include "functional_module/function_ids.h"
 #include "can_cooperation/commands/get_interior_vehicle_data_capabilities_request.h"
+#include "can_cooperation/commands/get_interior_vehicle_data_request.h"
+#include "can_cooperation/commands/set_interior_vehicle_data_request.h"
 
 // Disabled
-#include "can_cooperation/commands/get_interior_vehicle_data_request.h"
-//#include "can_cooperation/commands/set_interior_vehicle_data_request.h"
 //#include "can_cooperation/commands/on_interior_vehicle_data_notification.h"
 
 namespace can_cooperation {
@@ -59,11 +59,11 @@ utils::SharedPtr<commands::Command> MobileCommandFactory::CreateCommand(
           msg, can_module);
       break;
     }
-    //    case MobileFunctionID::SET_INTERIOR_VEHICLE_DATA: {
-    //      return utils::MakeShared<commands::SetInteriorVehicleDataRequest>(
-    //          msg, can_module);
-    //      break;
-    //    }
+    case MobileFunctionID::SET_INTERIOR_VEHICLE_DATA: {
+      return utils::MakeShared<commands::SetInteriorVehicleDataRequest>(
+          msg, can_module);
+      break;
+    }
     //    case MobileFunctionID::BUTTON_PRESS: {
     //      return utils::MakeShared<commands::ButtonPressRequest>(msg,
     //      can_module);

--- a/src/components/functional_module/test/include/mock_service.h
+++ b/src/components/functional_module/test/include/mock_service.h
@@ -81,7 +81,8 @@ class MockService : public Service {
                      bool(const std::string& application_id,
                           std::vector<std::string>* modules));
   MOCK_METHOD1(ValidateMessageBySchema,
-               bool(const application_manager::Message& message));
+               application_manager::MessageValidationResult(
+                   const application_manager::Message& message));
 };
 }
 // namespace application_manager

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -301,7 +301,8 @@ class ApplicationManager {
   virtual bool ManageMobileCommand(const commands::MessageSharedPtr message,
                                    commands::Command::CommandOrigin origin) = 0;
 
-  virtual bool ValidateMessageBySchema(const Message& message) = 0;
+  virtual MessageValidationResult ValidateMessageBySchema(
+      const Message& message) = 0;
 
   virtual mobile_api::HMILevel::eType GetDefaultHmiLevel(
       ApplicationConstSharedPtr application) const = 0;

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -284,7 +284,8 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD0(OnLowVoltage, void());
   MOCK_METHOD0(OnWakeUp, void());
   MOCK_METHOD1(ValidateMessageBySchema,
-               bool(const application_manager::Message& message));
+               application_manager::MessageValidationResult(
+                   const application_manager::Message& message));
 };
 
 }  // namespace application_manager_test

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1513,16 +1513,13 @@
  </enum>
 
  <struct name="Temperature">
-   <param name="unit" type="TemperatureUnit">
-     <description>Temperature Unit</description>
-   </param>
-   <param name="valueC" type="Float" minvalue="14.0" maxvalue="30.0" mandatory="false">
-     <description>Temperature Value in Celsius, the value range is for setter only</description>
-   </param>
-   <param name="valueF" type="Float" minvalue="60.0" maxvalue="90.0" mandatory="false">
-     <description>Temperature Value in Fahrenheit, the value range is for setter only</description>
-   </param>
- </struct>
+    <param name="unit" type="TemperatureUnit">
+      <description>Temperature Unit</description>
+    </param>
+    <param name="value" type="Float">
+      <description>Temperature Value in TemperatureUnit specified unit. Range depends on OEM and is not checked by SDL.</description>
+    </param>
+  </struct>
 
  <struct name="ClimateControlData">
    <param name="fanSpeed" type="Integer" minvalue="0" maxvalue="100" mandatory="false">
@@ -4718,6 +4715,21 @@
    <param name="interiorVehicleDataCapabilities" type="Common.RemoteControlCapabilities">
    </param>
  </function>
+
+ <function name="SetInteriorVehicleData" functionID="SetInteriorVehicleDataID" messagetype="request">
+    <param name="moduleData" type="Common.ModuleData">
+      <description>The module type and data to set</description>
+    </param>
+    <param name="appID" type="Integer" mandatory="true">
+      <description>Internal SDL-assigned ID of the related application</description>
+    </param>
+  </function>
+
+  <function name="SetInteriorVehicleData" functionID="SetInteriorVehicleDataID" messagetype="response">
+    <description>Used to set the values of one zone and one data type within that zone</description>
+    <param name="moduleData" type="Common.ModuleData">
+    </param>
+  </function>
 
 <function name="GetInteriorVehicleData" functionID="GetInteriorVehicleDataID" messagetype="request">
     <param name="moduleDescription" type="Common.ModuleDescription">

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -1523,11 +1523,8 @@
     <param name="unit" type="TemperatureUnit">
       <description>Temperature Unit</description>
     </param>
-    <param name="valueC" type="Float" minvalue="14.0" maxvalue="30.0" mandatory="false">
-      <description>Temperature Value in Celsius, the value range is for setter only</description>
-    </param>
-    <param name="valueF" type="Float" minvalue="60.0" maxvalue="90.0" mandatory="false">
-      <description>Temperature Value in Fahrenheit, the value range is for setter only</description>
+    <param name="value" type="Float">
+      <description>Temperature Value in TemperatureUnit specified unit. Range depends on OEM and is not checked by SDL.</description>
     </param>
   </struct>
 
@@ -2630,6 +2627,7 @@
 -->
     <element name="GetInteriorVehicleDataCapabilitiesID" value="100016" hexvalue="186B0" />
     <element name="GetInteriorVehicleDataID" value="100017" hexvalue="186B1" />
+    <element name="SetInteriorVehicleDataID" value="100018" hexvalue="186B2" />
 
   </enum>
 
@@ -5822,6 +5820,37 @@
     </param>
   </function>
 
+  <function name="SetInteriorVehicleData" functionID="SetInteriorVehicleDataID" messagetype="request">
+    <param name="moduleData" type="ModuleData">
+      <description>The module data to set for the requested RC module.</description>
+    </param>
+  </function>
+
+  <function name="SetInteriorVehicleData" functionID="SetInteriorVehicleDataID" messagetype="response">
+    <description>Used to set the values of one remote control module </description>
+    <param name="moduleData" type="ModuleData">
+    </param>
+    <param name="resultCode" type="Result" platform="documentation">
+      <description>See Result</description>
+      <element name="SUCCESS"/>
+      <element name="INVALID_DATA"/>
+      <element name="OUT_OF_MEMORY"/>
+      <element name="TOO_MANY_PENDING_REQUESTS"/>
+      <element name="APPLICATION_NOT_REGISTERED"/>
+      <element name="GENERIC_ERROR"/>
+      <element name="REJECTED"/>
+      <element name="IGNORED"/>
+      <element name="DISALLOWED"/>
+      <element name="USER_DISALLOWED"/>
+      <element name="READ_ONLY"/>
+      <element name="UNSUPPORTED_RESOURCE"/>
+    </param>
+    <param name="info" type="String" maxlength="1000" mandatory="false">
+    </param>
+    <param name="success" type="Boolean" platform="documentation">
+        <description> true if successful; false, if failed </description>
+    </param>
+  </function>
 <!-- Deprecating - covered by OnSystemRequest
   <function name="OnSyncPData" functionID="OnSyncPDataID" messagetype="notification" >
     <description>


### PR DESCRIPTION
- Changed method ApplicationManagerImpl::ValidateMessageBySchema
   to improve messages validation.
   Now it returns result code instead of bool
- GetInteriorVehicleData RPC changed according to new implementation of ValidateMessageBySchema
   method.
   Removed redundant function
- Implemented SetInteriorVehicleData request base functionality
