### PR TITLE
Add missed corr_id in error response from HMI

### DIFF
--- a/src/components/application_manager/include/application_manager/service.h
+++ b/src/components/application_manager/include/application_manager/service.h
@@ -44,7 +44,7 @@ namespace application_manager {
 enum TypeAccess { kNone, kDisallowed, kAllowed, kManual };
 
 enum MessageValidationResult {
-  SUCCESS,
+  SUCCESS = 0,
   INVALID_JSON,
   INVALID_METADATA,
   SCHEMA_MISMATCH,

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2107,6 +2107,8 @@ MessageValidationResult ApplicationManagerImpl::ValidateMessageBySchema(
           FromString<hmi_apis::FunctionID::eType, hmi_apis::messageType::eType>(
               message.json_message(), so);
       if (0 != conversion_result) {
+        LOG4CXX_WARN(logger_,
+                     "Failed to parse json from HMI: " << conversion_result);
         return INVALID_JSON;
       }
 

--- a/src/components/can_cooperation/src/can_module.cc
+++ b/src/components/can_cooperation/src/can_module.cc
@@ -193,7 +193,9 @@ ProcessResult CANModule::ProcessHMIMessage(
           service()->ValidateMessageBySchema(*msg);
       utils::SharedPtr<commands::Command> command =
           RCCommandFactory::CreateCommand(msg, *this);
-      if ((validation_result == application_manager::SUCCESS) && command) {
+      if ((validation_result ==
+           application_manager::MessageValidationResult::SUCCESS) &&
+          command) {
         command->Run();
         return ProcessResult::PROCESSED;
       }

--- a/src/components/can_cooperation/src/commands/base_command_request.cc
+++ b/src/components/can_cooperation/src/commands/base_command_request.cc
@@ -133,7 +133,7 @@ void BaseCommandRequest::SendRequest(const char* function_id,
 }
 
 bool BaseCommandRequest::Validate() {
-  return application_manager::SUCCESS ==
+  return application_manager::MessageValidationResult::SUCCESS ==
          service()->ValidateMessageBySchema(*message_);
 }
 

--- a/src/components/can_cooperation/src/commands/get_interior_vehicle_data_request.cc
+++ b/src/components/can_cooperation/src/commands/get_interior_vehicle_data_request.cc
@@ -72,8 +72,9 @@ void GetInteriorVehicleDataRequest::OnEvent(
       (functional_modules::hmi_api::get_interior_vehicle_data == event.id()));
 
   application_manager::Message& hmi_response = *(event.event_message());
-  const bool validate_result = application_manager::SUCCESS ==
-                               service()->ValidateMessageBySchema(hmi_response);
+  const bool validate_result =
+      application_manager::MessageValidationResult::SUCCESS ==
+      service()->ValidateMessageBySchema(hmi_response);
   LOG4CXX_DEBUG(logger_,
                 "HMI response validation result is " << validate_result);
   const Json::Value value =

--- a/src/components/can_cooperation/src/commands/set_interior_vehicle_data_request.cc
+++ b/src/components/can_cooperation/src/commands/set_interior_vehicle_data_request.cc
@@ -90,8 +90,9 @@ void SetInteriorVehicleDataRequest::OnEvent(
       (functional_modules::hmi_api::set_interior_vehicle_data == event.id()));
 
   application_manager::Message& hmi_response = *(event.event_message());
-  const bool validate_result = application_manager::SUCCESS ==
-                               service()->ValidateMessageBySchema(hmi_response);
+  const bool validate_result =
+      application_manager::MessageValidationResult::SUCCESS ==
+      service()->ValidateMessageBySchema(hmi_response);
   LOG4CXX_DEBUG(logger_,
                 "HMI response validation result is " << validate_result);
   const Json::Value value =

--- a/src/components/can_cooperation/test/src/can_module_test.cc
+++ b/src/components/can_cooperation/test/src/can_module_test.cc
@@ -134,13 +134,13 @@ TEST_F(CanModuleTest, ProcessMessageEmptyapps_List) {
         \"params\": {\"moduleData\": {\"moduleType\": \"CLIMATE\",\
         \"climateControlData\": {\"fanSpeed\": 100} }}}";
   message_->set_json_message(json);
-  // TODO(ILytvynenko): Uncomment after RC.OnInteriorVehicleData RPC
-  // implementation
-  // EXPECT_CALL(*mock_service_, GetApplications(module_.GetModuleID()))
-  //   .WillOnce(Return(apps_));
+
+  EXPECT_CALL(*mock_service_, ValidateMessageBySchema(_))
+      .WillOnce(Return(application_manager::SCHEMA_MISMATCH));
   EXPECT_CALL(*mock_service_, SendMessageToMobile(_)).Times(0);
+
   // EXPECT_EQ(ProcessResult::PROCESSED, module_.ProcessMessage(message_));
-  EXPECT_EQ(ProcessResult::CANNOT_PROCESS, module_.ProcessMessage(message_));
+  EXPECT_EQ(ProcessResult::CANNOT_PROCESS, module_.ProcessHMIMessage(message_));
 }
 
 TEST_F(CanModuleTest, ProcessMessagePass) {
@@ -168,23 +168,20 @@ TEST_F(CanModuleTest, ProcessMessagePass) {
 
   apps_.push_back(app0_);
   can_app_extention_->SubscribeToInteriorVehicleData(moduleDescription);
-  //  TODO(ILytvynenko): Uncomment after RC.OnInteriorVehicleData RPC
-  //  implementation
-  //  EXPECT_CALL(*app0_, QueryInterface(module_.GetModuleID()))
-  //      .WillOnce(Return(can_app_extention_));
-  //  EXPECT_CALL(*app0_, app_id()).WillRepeatedly(Return(1));
-  //  EXPECT_CALL(*mock_service_, GetApplications(module_.GetModuleID()))
-  //      .WillOnce(Return(apps_));
-  //  EXPECT_CALL(*mock_service_, GetApplication(1)).WillOnce(Return(app0_));
-  //  EXPECT_CALL(*mock_service_, CheckPolicyPermissions(_))
-  //      .WillOnce(Return(mobile_apis::Result::eType::SUCCESS));
-  //  EXPECT_CALL(*mock_service_, CheckModule(1,
-  //  "CLIMATE")).WillOnce(Return(true));
-  //  EXPECT_CALL(*mock_service_, SendMessageToMobile(_));
+  EXPECT_CALL(*mock_service_, ValidateMessageBySchema(_))
+      .WillOnce(Return(application_manager::SUCCESS));
+  EXPECT_CALL(*app0_, QueryInterface(module_.GetModuleID()))
+      .WillOnce(Return(can_app_extention_));
+  EXPECT_CALL(*app0_, app_id()).WillRepeatedly(Return(1));
+  EXPECT_CALL(*mock_service_, GetApplications(module_.GetModuleID()))
+      .WillOnce(Return(apps_));
+  EXPECT_CALL(*mock_service_, GetApplication(1)).WillOnce(Return(app0_));
+  EXPECT_CALL(*mock_service_, CheckPolicyPermissions(_))
+      .WillOnce(Return(mobile_apis::Result::eType::SUCCESS));
+  EXPECT_CALL(*mock_service_, CheckModule(1, "CLIMATE")).WillOnce(Return(true));
+  EXPECT_CALL(*mock_service_, SendMessageToMobile(_));
 
-  //  EXPECT_EQ(ProcessResult::PROCESSED, module_.ProcessMessage(message_));
-  EXPECT_EQ(ProcessResult::CANNOT_PROCESS, module_.ProcessMessage(message_));
-  std::cout << " !! " << std::endl;
+  EXPECT_EQ(ProcessResult::PROCESSED, module_.ProcessHMIMessage(message_));
 }
 
 TEST_F(CanModuleTest, RemoveAppExtensionPassWay) {

--- a/src/components/can_cooperation/test/src/can_module_test.cc
+++ b/src/components/can_cooperation/test/src/can_module_test.cc
@@ -136,7 +136,8 @@ TEST_F(CanModuleTest, ProcessMessageEmptyapps_List) {
   message_->set_json_message(json);
 
   EXPECT_CALL(*mock_service_, ValidateMessageBySchema(_))
-      .WillOnce(Return(application_manager::SCHEMA_MISMATCH));
+      .WillOnce(Return(
+          application_manager::MessageValidationResult::SCHEMA_MISMATCH));
   EXPECT_CALL(*mock_service_, SendMessageToMobile(_)).Times(0);
 
   // EXPECT_EQ(ProcessResult::PROCESSED, module_.ProcessMessage(message_));
@@ -169,7 +170,7 @@ TEST_F(CanModuleTest, ProcessMessagePass) {
   apps_.push_back(app0_);
   can_app_extention_->SubscribeToInteriorVehicleData(moduleDescription);
   EXPECT_CALL(*mock_service_, ValidateMessageBySchema(_))
-      .WillOnce(Return(application_manager::SUCCESS));
+      .WillOnce(Return(application_manager::MessageValidationResult::SUCCESS));
   EXPECT_CALL(*app0_, QueryInterface(module_.GetModuleID()))
       .WillOnce(Return(can_app_extention_));
   EXPECT_CALL(*app0_, app_id()).WillRepeatedly(Return(1));


### PR DESCRIPTION
In case if HMI send Error response SDL should read from json corr id and set it to internal message structure

Also add additional log for debug