### PR TITLE
Remove module description processing

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -265,9 +265,6 @@ class ApplicationManagerImpl
       const std::string& device_id,
       const std::string& policy_app_id) const OVERRIDE;
 
-  AppSharedPtrs applications_by_interior_vehicle_data(
-      smart_objects::SmartObject moduleDescription) OVERRIDE;
-
   uint32_t GetDeviceHandle(uint32_t connection_key) OVERRIDE;
   /**
    * @brief ChangeAppsHMILevel the function that will change application's

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3700,18 +3700,6 @@ struct TakeDeviceHandle {
   const ApplicationManager& app_mngr_;
 };
 
-struct SubscribedToInteriorVehicleDataPredicate {
-  smart_objects::SmartObject interior_module_data_ =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  SubscribedToInteriorVehicleDataPredicate(
-      smart_objects::SmartObject interior_module_data)
-      : interior_module_data_(interior_module_data) {}
-  bool operator()(const ApplicationSharedPtr app) const {
-    return app ? app->IsSubscribedToInteriorVehicleData(interior_module_data_)
-               : false;
-  }
-};
-
 ApplicationSharedPtr ApplicationManagerImpl::application(
     const std::string& device_id, const std::string& policy_app_id) const {
   connection_handler::DeviceHandle device_handle;
@@ -3736,15 +3724,6 @@ std::vector<std::string> ApplicationManagerImpl::devices(
                  std::back_inserter(devices),
                  TakeDeviceHandle(*this));
   return devices;
-}
-
-std::vector<ApplicationSharedPtr>
-ApplicationManagerImpl::applications_by_interior_vehicle_data(
-    smart_objects::SmartObject moduleDescription) {
-  SubscribedToInteriorVehicleDataPredicate finder(moduleDescription);
-  AppSharedPtrs apps = FindAllApps(applications(), finder);
-  LOG4CXX_DEBUG(logger_, " Found count: " << apps.size());
-  return apps;
 }
 
 bool ApplicationManagerImpl::IsAudioStreamingAllowed(

--- a/src/components/can_cooperation/include/can_cooperation/can_app_extension.h
+++ b/src/components/can_cooperation/include/can_cooperation/can_app_extension.h
@@ -71,19 +71,19 @@ class CANAppExtension : public application_manager::AppExtension {
    * @brief Subscribe to OnInteriorVehicleDataNotification
    * @param module interior data specification(zone, data type)
    */
-  void SubscribeToInteriorVehicleData(const Json::Value& moduleDescription);
+  void SubscribeToInteriorVehicleData(const Json::Value& module_type);
 
   /**
    * @brief Unsubscribe from OnInteriorVehicleDataNotification
    * @param module interior data specification(zone, data type)
    */
-  void UnsubscribeFromInteriorVehicleData(const Json::Value& moduleDescription);
+  void UnsubscribeFromInteriorVehicleData(const Json::Value& module_type);
 
   /**
    * @brief Check if application subscribed to OnInteriorVehicleDataNotification
    * @param module interior data specification(zone, data type)
    */
-  bool IsSubscibedToInteriorVehicleData(const Json::Value& moduleDescription);
+  bool IsSubscibedToInteriorVehicleData(const Json::Value& module_type);
 
  private:
   bool is_control_given_;

--- a/src/components/can_cooperation/include/can_cooperation/can_module_constants.h
+++ b/src/components/can_cooperation/include/can_cooperation/can_module_constants.h
@@ -155,7 +155,6 @@ const char kModuleData[] = "moduleData";
 // SetInteriorVehicleData response
 
 // GetInteriorVehicleData request
-const char kModuleDescription[] = "moduleDescription";
 const char kSubscribe[] = "subscribe";
 // GetInteriorVehicleData request
 

--- a/src/components/can_cooperation/src/can_app_extension.cc
+++ b/src/components/can_cooperation/src/can_app_extension.cc
@@ -47,19 +47,19 @@ void CANAppExtension::GiveControl(bool is_control_given) {
 }
 
 void CANAppExtension::SubscribeToInteriorVehicleData(
-    const Json::Value& moduleDescription) {
-  subscribed_interior_vehicle_data_.insert(moduleDescription);
+    const Json::Value& module_type) {
+  subscribed_interior_vehicle_data_.insert(module_type);
 }
 
 void CANAppExtension::UnsubscribeFromInteriorVehicleData(
-    const Json::Value& moduleDescription) {
-  subscribed_interior_vehicle_data_.erase(moduleDescription);
+    const Json::Value& module_type) {
+  subscribed_interior_vehicle_data_.erase(module_type);
 }
 
 bool CANAppExtension::IsSubscibedToInteriorVehicleData(
-    const Json::Value& moduleDescription) {
+    const Json::Value& module_type) {
   std::set<Json::Value>::iterator it =
-      subscribed_interior_vehicle_data_.find(moduleDescription);
+      subscribed_interior_vehicle_data_.find(module_type);
 
   return (it != subscribed_interior_vehicle_data_.end());
 }

--- a/src/components/can_cooperation/src/commands/get_interior_vehicle_data_request.cc
+++ b/src/components/can_cooperation/src/commands/get_interior_vehicle_data_request.cc
@@ -119,7 +119,7 @@ void GetInteriorVehicleDataRequest::ProccessSubscription(
                      << kIsSubscribed << " missed in hmi response");
     response_params_[kIsSubscribed] =
         extension->IsSubscibedToInteriorVehicleData(
-            request_params[kModuleDescription]);
+            request_params[kModuleType]);
     return;
   }
 
@@ -135,21 +135,17 @@ void GetInteriorVehicleDataRequest::ProccessSubscription(
   response_params_[kIsSubscribed] = response_subscribe;
   if (request_subscribe == response_subscribe) {
     if (response_subscribe) {
-      extension->SubscribeToInteriorVehicleData(
-          request_params[kModuleDescription]);
+      extension->SubscribeToInteriorVehicleData(request_params[kModuleType]);
     } else {
       extension->UnsubscribeFromInteriorVehicleData(
-          request_params[kModuleDescription]);
+          request_params[kModuleType]);
     }
   }
 }
 
 std::string GetInteriorVehicleDataRequest::ModuleType(
     const Json::Value& message) {
-  return message.get(message_params::kModuleDescription,
-                     Json::Value(Json::objectValue))
-      .get(message_params::kModuleType, Json::Value(""))
-      .asString();
+  return message.get(message_params::kModuleType, "").asString();
 }
 
 }  // namespace commands

--- a/src/components/can_cooperation/src/commands/on_interior_vehicle_data_notification.cc
+++ b/src/components/can_cooperation/src/commands/on_interior_vehicle_data_notification.cc
@@ -56,15 +56,13 @@ OnInteriorVehicleDataNotification::~OnInteriorVehicleDataNotification() {}
 void OnInteriorVehicleDataNotification::Execute() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  Json::Value moduleDescription(Json::ValueType::objectValue);
   Json::Value json;
 
   application_manager::MessagePtr msg = message();
 
   json = MessageHelper::StringToValue(msg->json_message());
 
-  moduleDescription[message_params::kModuleType] =
-      json[message_params::kModuleData][message_params::kModuleType];
+  Json::Value module_type = json[message_params::kModuleType];
 
   typedef std::vector<application_manager::ApplicationSharedPtr> AppPtrs;
   AppPtrs apps = service_->GetApplications(can_module_.GetModuleID());
@@ -77,7 +75,7 @@ void OnInteriorVehicleDataNotification::Execute() {
         application_manager::AppExtensionPtr::static_pointer_cast<
             CANAppExtension>(app.QueryInterface(can_module_.GetModuleID()));
     DCHECK(extension);
-    if (extension->IsSubscibedToInteriorVehicleData(moduleDescription)) {
+    if (extension->IsSubscibedToInteriorVehicleData(module_type)) {
       application_manager::MessagePtr message =
           utils::MakeShared<application_manager::Message>(*msg);
       message->set_message_type(
@@ -94,12 +92,7 @@ void OnInteriorVehicleDataNotification::Execute() {
 
 std::string OnInteriorVehicleDataNotification::ModuleType(
     const Json::Value& message) {
-  const Json::Value module_data =
-      message.get(message_params::kModuleData, Json::Value(Json::objectValue));
-  const Json::Value module_type =
-      module_data.get(message_params::kModuleType, Json::Value(""));
-
-  return module_type.asString();
+  return message.get(message_params::kModuleType, "").asString();
 }
 
 std::vector<std::string> OnInteriorVehicleDataNotification::ControlData(

--- a/src/components/can_cooperation/src/commands/set_interior_vehicle_data_request.cc
+++ b/src/components/can_cooperation/src/commands/set_interior_vehicle_data_request.cc
@@ -111,10 +111,7 @@ void SetInteriorVehicleDataRequest::OnEvent(
 
 std::string SetInteriorVehicleDataRequest::ModuleType(
     const Json::Value& message) {
-  return message.get(message_params::kModuleData,
-                     Json::Value(Json::objectValue))
-      .get(message_params::kModuleType, Json::Value(""))
-      .asString();
+  return message.get(message_params::kModuleType, "").asString();
 }
 
 std::vector<std::string> SetInteriorVehicleDataRequest::ControlData(

--- a/src/components/can_cooperation/test/src/can_module_test.cc
+++ b/src/components/can_cooperation/test/src/can_module_test.cc
@@ -161,14 +161,10 @@ TEST_F(CanModuleTest, ProcessMessagePass) {
   message_->set_binary_data(data);
 
   Json::Value json_value = MessageHelper::StringToValue(json);
-  Json::Value moduleDescription;
-
-  moduleDescription[message_params::kModuleType] =
-      json_value[json_keys::kParams][message_params::kModuleData]
-                [message_params::kModuleType];
+  Json::Value module_type = json_value[message_params::kModuleType];
 
   apps_.push_back(app0_);
-  can_app_extention_->SubscribeToInteriorVehicleData(moduleDescription);
+  can_app_extention_->SubscribeToInteriorVehicleData(module_type);
   EXPECT_CALL(*mock_service_, ValidateMessageBySchema(_))
       .WillOnce(Return(application_manager::MessageValidationResult::SUCCESS));
   EXPECT_CALL(*app0_, QueryInterface(module_.GetModuleID()))

--- a/src/components/can_cooperation/test/src/vehicle_data_subscription_test.cc
+++ b/src/components/can_cooperation/test/src/vehicle_data_subscription_test.cc
@@ -115,8 +115,7 @@ TEST(VehicleDataSubscription, CompareDifferentNesting) {
 
 TEST(VehicleDataSubscription, CompareModuleDesciption) {
   Json::Value json1;
-  json1["moduleDescription"] = Json::Value(Json::ValueType::objectValue);
-  json1["moduleDescription"]["moduleType"] = "RADIO";
+  json1["moduleType"] = "RADIO";
 
   Json::Value json2;
   json2["moduleData"] = Json::Value(Json::ValueType::objectValue);
@@ -124,15 +123,15 @@ TEST(VehicleDataSubscription, CompareModuleDesciption) {
       Json::Value(Json::ValueType::objectValue);
   json2["moduleData"]["moduleType"] = "RADIO";
 
-  ASSERT_FALSE(json1["moduleDescription"] == json2["moduleData"]);
+  ASSERT_FALSE(json1["moduleType"] == json2["moduleData"]);
 
   Json::Value json3;
   json3["moduleType"] = json2["moduleData"]["moduleType"];
 
-  ASSERT_TRUE(json1["moduleDescription"] == json3);
+  ASSERT_TRUE(json1["moduleType"] == json3);
 
   std::set<Json::Value> subscribed;
-  subscribed.insert(json1["moduleDescription"]);
+  subscribed.insert(json1["moduleType"]);
   Json::Value null_val(Json::ValueType::nullValue);
   subscribed.insert(null_val);
   ASSERT_FALSE(subscribed.end() == subscribed.find(json3));

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -167,9 +167,6 @@ class ApplicationManager {
   virtual void SubscribeToHMINotification(
       const std::string& hmi_notification) = 0;
 
-  virtual AppSharedPtrs applications_by_interior_vehicle_data(
-      smart_objects::SmartObject moduleDescription) = 0;
-
   virtual uint32_t GetDeviceHandle(uint32_t connection_key) = 0;
 
   /**

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -83,9 +83,6 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                          const std::string& policy_app_id));
   MOCK_METHOD1(SubscribeToHMINotification,
                void(const std::string& hmi_notification));
-  MOCK_METHOD1(applications_by_interior_vehicle_data,
-               application_manager::AppSharedPtrs(
-                   smart_objects::SmartObject moduleDescription));
   MOCK_METHOD1(GetDeviceHandle, uint32_t(uint32_t connection_key));
   MOCK_CONST_METHOD1(IsAudioStreamingAllowed, bool(uint32_t connection_key));
   MOCK_CONST_METHOD1(IsVideoStreamingAllowed, bool(uint32_t connection_key));

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1357,12 +1357,6 @@
    <element name="RADIO"/>
  </enum>
 
- <struct name="ModuleDescription">
-   <param name="moduleType" type="Common.ModuleType">
-   </param>
- </struct>
-
-
  <enum name="RadioBand">
    <element name="AM"/>
    <element name="FM"/>
@@ -4710,25 +4704,25 @@
   </function>
 
 <function name="GetInteriorVehicleData" functionID="GetInteriorVehicleDataID" messagetype="request">
-    <param name="moduleDescription" type="Common.ModuleDescription">
-      <description>The name and module data to retrieve from the vehicle for that name</description>
-    </param>
-    <param name="subscribe" type="Boolean" mandatory="false" defvalue="false">
-      <description>If subscribe is true, the head unit will send onInteriorVehicleData notifications for the moduleDescription</description>
-    </param>
-    <param name="appID" type="Integer" mandatory="true">
-      <description>Internal SDL-assigned ID of the related application</description>
-    </param>
+  <param name="moduleType" type="Common.ModuleType">
+    <description>The module data to retrieve from the vehicle for that type</description>
+  </param>
+  <param name="subscribe" type="Boolean" mandatory="false" defvalue="false">
+    <description>If subscribe is true, the head unit will send onInteriorVehicleData notifications for the module type</description>
+  </param>
+  <param name="appID" type="Integer" mandatory="true">
+    <description>Internal SDL-assigned ID of the related application</description>
+  </param>
 </function>
 
 <function name="GetInteriorVehicleData" functionID="GetInteriorVehicleDataID" messagetype="response">
-    <param name="moduleData" type="Common.ModuleData">
-    </param>
-    <param name="isSubscribed" type="Boolean" mandatory="false" >
-      <description>Is a conditional-mandatory parameter: must be returned in case "subscribe" parameter was present in the related request.
-      if "true" - the "moduleDescription" from request is successfully subscribed and  the head unit will send onInteriorVehicleData notifications for the moduleDescription.
-      if "false" - the "moduleDescription" from request is either unsubscribed or failed to subscribe.</description>
-    </param>
+  <param name="moduleData" type="Common.ModuleData">
+  </param>
+  <param name="isSubscribed" type="Boolean" mandatory="false" >
+    <description>Is a conditional-mandatory parameter: must be returned in case "subscribe" parameter was present in the related request.
+    if "true" - the "moduleType" from request is successfully subscribed and  the head unit will send onInteriorVehicleData notifications for the moduleDescription.
+    if "false" - the "moduleType" from request is either unsubscribed or failed to subscribe.</description>
+  </param>
 </function>
 
 

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -1364,12 +1364,6 @@
     <element name="RADIO"/>
   </enum>
 
-  <struct name="ModuleDescription">
-    <param name="moduleType" type="ModuleType">
-    </param>
-  </struct>
-
-
   <enum name="RadioBand">
     <element name="AM"/>
     <element name="FM"/>
@@ -5746,8 +5740,11 @@
   </function>
 
 <function name="GetInteriorVehicleData" functionID="GetInteriorVehicleDataID" messagetype="request">
-        <param name="moduleDescription" type="ModuleDescription">
-                <description>The name and module data to retrieve from the vehicle for that name</description>
+        <param name="moduleType" type="ModuleType">
+              <description>
+                The type of a RC module to retrieve module data from the vehicle.
+                In the future, this should be the Identification of a module.
+              </description>
         </param>
         <param name="subscribe" type="Boolean" mandatory="false" defvalue="false">
                 <description>If subscribe is true, the head unit will send onInteriorVehicleData notifications for the moduleDescription</description>


### PR DESCRIPTION
Remove ModuleDescription struct form API's. Use Module Type insted.

Previous API was : 
```xml
<function name="GetInteriorVehicleData" functionID="GetInteriorVehicleDataID" messagetype="request">
    <param name="moduleDescription" type="Common.ModuleDescription">
      <description>The name and module data to retrieve from the vehicle for that name</description>
</param>
```

New API's: 

```xml
<function name="GetInteriorVehicleData" functionID="GetInteriorVehicleDataID" messagetype="request">
  <param name="moduleType" type="Common.ModuleType">
    <description>The module data to retrieve from the vehicle for that type</description>
</param>
```
