### PR TITLE
Fix extracting module type from mobile message in SetInteriorVehicleData

### DIFF
--- a/src/components/can_cooperation/src/commands/set_interior_vehicle_data_request.cc
+++ b/src/components/can_cooperation/src/commands/set_interior_vehicle_data_request.cc
@@ -111,9 +111,10 @@ void SetInteriorVehicleDataRequest::OnEvent(
 
 std::string SetInteriorVehicleDataRequest::ModuleType(
     const Json::Value& message) {
-  return message.get(message_params::kModuleType, "").asString();
+  const Json::Value& module_data =
+      message.get(message_params::kModuleData, Json::Value(Json::objectValue));
+  return module_data.get(message_params::kModuleType, "").asString();
 }
-
 std::vector<std::string> SetInteriorVehicleDataRequest::ControlData(
     const Json::Value& message) {
   Json::Value data =


### PR DESCRIPTION
According API module type is separated in module_data struct.
SDL should read module_data and read module_type from it. 
