### PR TITLE
Implement READ_ONLY parameters handling in SetInteriorVehicleData mobile request

### DIFF
--- a/src/components/remote_control/include/remote_control/commands/set_interior_vehicle_data_request.h
+++ b/src/components/remote_control/include/remote_control/commands/set_interior_vehicle_data_request.h
@@ -69,6 +69,26 @@ class SetInteriorVehicleDataRequest : public BaseCommandRequest {
                                             std::string>& event);
 
   /**
+   * @brief Method that check if READ_ONLY parameters present
+   * @param request_params params from received message
+   * @return true if present , false - otherwise
+   */
+  bool AreReadOnlyParamsPresent(const Json::Value& request_params);
+
+  /**
+   * @brief Method that check if all request parameters are READ_ONLY
+   * @param request_params params from received message
+   * @return true if all are read only , false - otherwise
+   */
+  bool AreAllParamsReadOnly(const Json::Value& request_params);
+
+  /**
+   * @brief Method that cuts-off READ_ONLY parameters
+   * @param request_params params to handle
+   */
+  void CutOffReadOnlyParams(Json::Value& request_params);
+
+  /**
    * @brief SetInteriorVehicleDataRequest class destructor
    */
   virtual ~SetInteriorVehicleDataRequest();

--- a/src/components/remote_control/include/remote_control/rc_module_constants.h
+++ b/src/components/remote_control/include/remote_control/rc_module_constants.h
@@ -209,14 +209,16 @@ const char kState[] = "state";
 
 // ClimateControlData struct
 const char kFanSpeed[] = "fanSpeed";
-const char kCurrentTemp[] = "currentTemp";
-const char kDesiredTemp[] = "desiredTemp";
+const char kCurrentTemperature[] = "currentTemperature";
+const char kDesiredTemperature[] = "desiredTemperature";
 const char kTemperatureUnit[] = "temperatureUnit";
 const char kACEnable[] = "acEnable";
 const char kCirculateAirEnable[] = "circulateAirEnable";
 const char kAutoModeEnable[] = "autoModeEnable";
 const char kDefrostZone[] = "defrostZone";
 const char kDualModeEnable[] = "dualModeEnable";
+const char kACMaxEnable[] = "acMaxEnable";
+const char kVentilationMode[] = "ventilationMode";
 // ClimateControlData struct
 
 // ModuleData struct
@@ -261,7 +263,6 @@ const char kAll[] = "ALL";
 // DefrostZone enum
 
 // TemperatureUnit enum
-const char kKelvin[] = "KELVIN";
 const char kFahrenheit[] = "FAHRENHEIT";
 const char kCelsius[] = "CELSIUS";
 // TemperatureUnit enum


### PR DESCRIPTION
- Added response to mobile generation when all request module type params
   are **READ ONLY**
- Added cutting-off of **READ ONLY** params when in request present both **READ ONLY** and **settable**   parameters