### PR TITLE
Change boundary values and manadatory for CT param

### DIFF
--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1348,7 +1348,7 @@
    <param name="RT" type="String" minlength="0" maxlength="64">
      <description>Radio Text</description>
    </param>
-   <param name="CT" type="String" minlength="24" maxlength="24">
+   <param name="CT" type="String" minlength="22" maxlength="28" mandatory="false">
      <description>The clock text in UTC format as YYYY-MM-DDThh:mm:ss.sTZD</description>
    </param>
    <param name="PI" type="String" minlength="0" maxlength="6">

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -1377,7 +1377,7 @@
     <param name="RT" type="String" minlength="0" maxlength="64">
       <description>Radio Text</description>
     </param>
-    <param name="CT" type="String" minlength="24" maxlength="24">
+    <param name="CT" type="String" minlength="22" maxlength="28" mandatory="false">
       <description>The clock text in UTC format as YYYY-MM-DDThh:mm:ss.sTZD</description>
     </param>
     <param name="PI" type="String" minlength="0" maxlength="6">


### PR DESCRIPTION
According to new API - param CT from RdsData must be like:
<param name="CT" type="String" minlength="22" maxlength="28"
mandatory="false">
in Mobile as well as in HMI API.