### PR TITLE
Feature/on remote control settings

### DIFF
--- a/src/components/functional_module/include/functional_module/function_ids.h
+++ b/src/components/functional_module/include/functional_module/function_ids.h
@@ -35,12 +35,13 @@
 
 namespace functional_modules {
 
-enum MobileFunctionID {
+enum RCFunctionID {
   // Remote SDL functions ids
   BUTTON_PRESS = 41,
   GET_INTERIOR_VEHICLE_DATA = 43,
   SET_INTERIOR_VEHICLE_DATA = 44,
   ON_INTERIOR_VEHICLE_DATA = 32783,
+  ON_REMOTE_CONTROL_SETTINGS,
 };
 
 namespace hmi_api {
@@ -48,6 +49,7 @@ const char get_interior_vehicle_data[] = "RC.GetInteriorVehicleData";
 const char set_interior_vehicle_data[] = "RC.SetInteriorVehicleData";
 const char on_interior_vehicle_data[] = "RC.OnInteriorVehicleData";
 const char button_press[] = "Buttons.ButtonPress";
+const char on_remote_control_settings[] = "RC.OnRemoteControlSettings";
 
 const char get_user_consent[] = "RC.GetInteriorVehicleDataConsent";
 const char on_app_deactivated[] = "BasicCommunication.OnAppDeactivated";

--- a/src/components/functional_module/include/functional_module/generic_module.h
+++ b/src/components/functional_module/include/functional_module/generic_module.h
@@ -60,7 +60,7 @@ typedef utils::SharedPtr<GenericModule> ModulePtr;
 struct PluginInfo {
   std::string name;
   int version;
-  std::deque<MobileFunctionID> mobile_function_list;
+  std::deque<RCFunctionID> rc_function_list;
   std::deque<HMIFunctionID> hmi_function_list;
 };
 

--- a/src/components/functional_module/include/functional_module/plugin_manager.h
+++ b/src/components/functional_module/include/functional_module/plugin_manager.h
@@ -109,7 +109,7 @@ class PluginManager : public ModuleObserver {
  private:
   Modules plugins_;
   std::map<ModuleID, void*> dlls_;
-  std::map<MobileFunctionID, ModulePtr> mobile_subscribers_;
+  std::map<RCFunctionID, ModulePtr> mobile_subscribers_;
   std::map<HMIFunctionID, ModulePtr> hmi_subscribers_;
   application_manager::ServicePtr service_;
 

--- a/src/components/functional_module/src/generic_module.cc
+++ b/src/components/functional_module/src/generic_module.cc
@@ -1,5 +1,4 @@
 #include "functional_module/generic_module.h"
-
 namespace functional_modules {
 
 typedef std::deque<ModuleObserver*>::iterator ModuleObserverIterator;
@@ -50,6 +49,7 @@ void GenericModule::OnServiceStateChanged(ServiceState state) {
   if (HMI_ADAPTER_INITIALIZED == state_) {
     // We must subscribe to necessary HMI notifications
     service_->SubscribeToHMINotification(hmi_api::on_interior_vehicle_data);
+    service_->SubscribeToHMINotification(hmi_api::on_remote_control_settings);
     // Disabled
     //    service_->SubscribeToHMINotification(hmi_api::on_reverse_apps_allowing);
     //    service_->SubscribeToHMINotification(hmi_api::on_device_rank_changed);

--- a/src/components/functional_module/test/plugins/mock_generic_module.cc
+++ b/src/components/functional_module/test/plugins/mock_generic_module.cc
@@ -1,7 +1,7 @@
 #include "mock_generic_module.h"
 
 using functional_modules::GenericModule;
-using functional_modules::MobileFunctionID;
+using functional_modules::RCFunctionID;
 using functional_modules::PluginInfo;
 
 using ::testing::_;
@@ -11,7 +11,7 @@ MockGenericModule::MockGenericModule() : GenericModule(19) {
   PluginInfo info;
   info.name = "MockGenericModule";
   info.version = 1;
-  info.mobile_function_list.push_back(static_cast<MobileFunctionID>(101));
+  info.rc_function_list.push_back(static_cast<RCFunctionID>(101));
   info.hmi_function_list.push_back("HMI-Func-1");
 
   EXPECT_CALL(*this, GetPluginInfo()).Times(2).WillRepeatedly(Return(info));

--- a/src/components/functional_module/test/src/generic_module_test.cc
+++ b/src/components/functional_module/test/src/generic_module_test.cc
@@ -41,7 +41,7 @@ TEST(GenericModuleTest, OnServiceStateChangedPass) {
   ServicePtr exp_service(mock_service);
   module.set_service(exp_service);
 
-  EXPECT_CALL(*mock_service, SubscribeToHMINotification(_)).Times(1);
+  EXPECT_CALL(*mock_service, SubscribeToHMINotification(_)).Times(2);
 
   module.OnServiceStateChanged(HMI_ADAPTER_INITIALIZED);
 }

--- a/src/components/hmi_message_handler/src/messagebroker_adapter.cc
+++ b/src/components/hmi_message_handler/src/messagebroker_adapter.cc
@@ -138,6 +138,7 @@ void MessageBrokerAdapter::SubscribeTo() {
   MessageBrokerController::subscribeTo("BasicCommunication.OnEventChanged");
   MessageBrokerController::subscribeTo("RC.OnDeviceRankChanged");
   MessageBrokerController::subscribeTo("RC.OnInteriorVehicleData");
+  MessageBrokerController::subscribeTo("RC.OnRemoteControlSettings");
 
   LOG4CXX_INFO(logger_, "Subscribed to notifications.");
 }

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1607,6 +1607,13 @@
   </element>
 </enum>
 
+<enum name="RCAccessMode">
+  <description>Enumeration that describes possible remote control access mode the application might be in on HU.</description>
+  <element name="AUTO_ALLOW"/>
+  <element name="AUTO_DENY"/>
+  <element name="ASK_DRIVER"/>
+</enum>
+
 <!-- End Remote Control -->
 <struct name="TextField">
   <param name="name" type="Common.TextFieldName">
@@ -4723,6 +4730,14 @@
   </param>
 </function>
 
+<function name="OnRemoteControlSettings" messagetype="notification">
+  <description>Sender: vehicle -> RSDL. Notification about remote-control settings changed. Sent after User`s choice through HMI.</description>
+  <param name="allowed" type="Boolean" mandatory="false" >
+    <description>If "true" - RC is allowed; if "false" - RC is disallowed.</description>
+  </param>
+  <param name="accessMode" type="Common.RCAccessMode" mandatory="false" >
+    <description>The remote control access mode specified by the driver via HMI.</description>
+  </param>
+</function>
 </interface>
-
 </interfaces>

--- a/src/components/remote_control/include/remote_control/commands/base_command_notification.h
+++ b/src/components/remote_control/include/remote_control/commands/base_command_notification.h
@@ -90,9 +90,9 @@ class BaseCommandNotification : public Command {
   virtual void Execute() = 0;
 
   /**
-   * @brief executes specific message validation logic of children classes
+   * @brief Validates notification by xml schema
    */
-  virtual bool Validate() = 0;
+  virtual bool Validate();
 
   virtual std::string ModuleType(const Json::Value& message);
   virtual std::vector<std::string> ControlData(const Json::Value& message);

--- a/src/components/remote_control/include/remote_control/commands/on_remote_control_settings_notification.h
+++ b/src/components/remote_control/include/remote_control/commands/on_remote_control_settings_notification.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2013, Ford Motor Company
+ Copyright (c) 2017, Ford Motor Company
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -30,8 +30,8 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SRC_COMPONENTS_REMOTE_CONTROL_INCLUDE_REMOTE_CONTROL_COMMANDS_ON_INTERIOR_VEHICLE_DATA_NOTIFICATION_H_
-#define SRC_COMPONENTS_REMOTE_CONTROL_INCLUDE_REMOTE_CONTROL_COMMANDS_ON_INTERIOR_VEHICLE_DATA_NOTIFICATION_H_
+#ifndef SRC_COMPONENTS_REMOTE_CONTROL_INCLUDE_REMOTE_CONTROL_COMMANDS_ON_REMOTE_CONTROL_SETTINGS_NOTIFICATION_H_
+#define SRC_COMPONENTS_REMOTE_CONTROL_INCLUDE_REMOTE_CONTROL_COMMANDS_ON_REMOTE_CONTROL_SETTINGS_NOTIFICATION_H_
 
 #include "utils/macro.h"
 #include "remote_control/commands/base_command_notification.h"
@@ -41,16 +41,17 @@ namespace remote_control {
 namespace commands {
 
 /**
- * @brief OnInteriorVehicleDataNotification command class
+ * @brief OnRemoteControlSettingsNotification command class
  */
-class OnInteriorVehicleDataNotification : public BaseCommandNotification {
+class OnRemoteControlSettingsNotification : public BaseCommandNotification {
  public:
   /**
-   * @brief OnInteriorVehicleDataNotification class constructor
+   * @brief OnRemoteControlSettingsNotification class constructor
    *
    * @param message Message with notification
+   * @param rc_module Module used for handling RC functionality
    **/
-  OnInteriorVehicleDataNotification(
+  OnRemoteControlSettingsNotification(
       const application_manager::MessagePtr& message,
       RemotePluginInterface& rc_module);
 
@@ -59,17 +60,20 @@ class OnInteriorVehicleDataNotification : public BaseCommandNotification {
    */
   void Execute() FINAL;
 
+ private:
   /**
-   * @brief OnInteriorVehicleDataNotification class destructor
+   * @brief Disalows RC functionality for all RC apps
+   * All registered apps with appHMIType REMOTE_CONTROL will be put to NONE hmi
+   * level
+   * OnHMIStatus (NONE) will be send to such apps
+   * All registered apps will be unsubsribed from OnInteriorVehicleData
+   * notifications
    */
-  virtual ~OnInteriorVehicleDataNotification();
-
- protected:
-  std::string ModuleType(const Json::Value& message) FINAL;
+  void DisallowRCFunctionality();
 };
 
 }  // namespace commands
 
 }  // namespace remote_control
 
-#endif  // SRC_COMPONENTS_REMOTE_CONTROL_INCLUDE_REMOTE_CONTROL_COMMANDS_ON_INTERIOR_VEHICLE_DATA_NOTIFICATION_H_
+#endif  // SRC_COMPONENTS_REMOTE_CONTROL_INCLUDE_REMOTE_CONTROL_COMMANDS_ON_REMOTE_CONTROL_SETTINGS_NOTIFICATION_H_

--- a/src/components/remote_control/include/remote_control/message_helper.h
+++ b/src/components/remote_control/include/remote_control/message_helper.h
@@ -39,6 +39,7 @@
 
 #include "utils/macro.h"
 #include "json/json.h"
+#include "interfaces/HMI_API.h"
 #include "functional_module/function_ids.h"
 #include "remote_control/remote_plugin_interface.h"
 #include "application_manager/message.h"
@@ -57,7 +58,7 @@ class MessageHelper {
    */
   static uint32_t GetNextRCCorrelationID();
   static const std::string GetMobileAPIName(
-      functional_modules::MobileFunctionID func_id);
+      functional_modules::RCFunctionID func_id);
 
   /**
    * @brief Convert Json::Value to std::string
@@ -105,21 +106,26 @@ class MessageHelper {
       const Json::Value& message_params,
       RemotePluginInterface& rc_module);
 
+  /** @brief Converts string to hmi AccessMode enum value
+   * @param access_mode stringified value
+   * @return hmi AccessMode enum value if succedeed, otherwise - INVALID_ENUM
+   * value
+   */
+  static hmi_apis::Common_RCAccessMode::eType AccessModeFromString(
+      const std::string& access_mode);
+
  private:
   MessageHelper();
 
   static uint32_t next_correlation_id_;
-  static const std::map<functional_modules::MobileFunctionID, std::string>
+  static const std::map<functional_modules::RCFunctionID, std::string>
       kMobileAPINames;
   DISALLOW_COPY_AND_ASSIGN(MessageHelper);
 };
 
-/**
- * @brief Check for existence of specified key in Json::Value
- *
+/** @brief Check for existence of specified key in Json::Value
  * @param value Value with json
  * @param key string with key name
- *
  * @return true if key exist
  */
 bool IsMember(const Json::Value& value, const std::string& key);

--- a/src/components/remote_control/include/remote_control/rc_module_constants.h
+++ b/src/components/remote_control/include/remote_control/rc_module_constants.h
@@ -167,9 +167,10 @@ const char kIsSubscribed[] = "isSubscribed";
 // const char kModuleData[] = "moduleData";
 // OnInteriorVehicleData notification
 
-// OnReverseAppsAllowing notification
+// OnRemoteControlSettings notification
+const char kAccessMode[] = "accessMode";
 const char kAllowed[] = "allowed";
-// OnReverseAppsAllowing notification
+// OnRemoteControlSettings notification
 
 // RC.OnDriverRankChanged notification
 const char kDevice[] = "device";
@@ -292,7 +293,13 @@ const char kRepeat[] = "REPEAT";
 const char kLong[] = "LONG";
 const char kShort[] = "SHORT";
 // ButtonPressMode enum
-}  //  namespace enums
+
+// Access mode enum
+const char kAutoAllow[] = "AUTO_ALLOW";
+const char kAutoDeny[] = "AUTO_DENY";
+const char kAskDriver[] = "ASK_DRIVER";
+// Access mode enum
+}  //  namespace enums_value
 
 }  //  namespace remote_control
 

--- a/src/components/remote_control/include/remote_control/remote_control_plugin.h
+++ b/src/components/remote_control/include/remote_control/remote_control_plugin.h
@@ -111,7 +111,7 @@ class RemoteControlPlugin : public RemotePluginInterface {
 
   RCEventDispatcher& event_dispatcher() OVERRIDE;
 
-  ResourceAllocationManager& resource_allocator_manager() OVERRIDE;
+  ResourceAllocationManager& resource_allocation_manager() OVERRIDE;
 
  protected:
   /**

--- a/src/components/remote_control/include/remote_control/remote_plugin_interface.h
+++ b/src/components/remote_control/include/remote_control/remote_plugin_interface.h
@@ -118,7 +118,7 @@ class RemotePluginInterface : public functional_modules::GenericModule {
 
   virtual RCPluginEventDispatcher& event_dispatcher() = 0;
 
-  virtual ResourceAllocationManager& resource_allocator_manager() = 0;
+  virtual ResourceAllocationManager& resource_allocation_manager() = 0;
 
  protected:
   /**

--- a/src/components/remote_control/include/remote_control/resource_allocation_manager.h
+++ b/src/components/remote_control/include/remote_control/resource_allocation_manager.h
@@ -3,6 +3,7 @@
 #include <string>
 #include "utils/macro.h"
 #include "utils/shared_ptr.h"
+#include "interfaces/HMI_API.h"
 #include "remote_control/event_engine/event.h"
 
 namespace remote_control {
@@ -13,13 +14,6 @@ namespace remote_control {
 namespace AcquireResult {
 enum eType { ALLOWED = 0, IN_USE, ASK_DRIVER, REJECTED };
 }
-
-/**
- * Enum contains list of access modes
- */
-namespace AccessMode {
-enum eType { AUTO_ALLOW = 0, AUTO_DENY, ASK_DRIVER };
-}  // AccessMode
 
 /**
  * @brief The AskDriverCallBack class callback for GetInteriourConsent response
@@ -71,6 +65,13 @@ class ResourceAllocationManager {
   virtual void AskDriver(const std::string& module_type,
                          const uint32_t app_id,
                          AskDriverCallBackPtr callback) = 0;
+
+  /**
+   * @brief Set current access mode for acquiring resource
+   * @param access_mode
+   */
+  virtual void SetAccessMode(
+      const hmi_apis::Common_RCAccessMode::eType access_mode) = 0;
 
   virtual ~ResourceAllocationManager() = 0;
 };

--- a/src/components/remote_control/include/remote_control/resource_allocation_manager_impl.h
+++ b/src/components/remote_control/include/remote_control/resource_allocation_manager_impl.h
@@ -18,7 +18,8 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
                  const uint32_t hmi_app_id,
                  AskDriverCallBackPtr callback) OVERRIDE FINAL;
 
-  void SetAccessMode(const AccessMode::eType access_mode);
+  void SetAccessMode(
+      const hmi_apis::Common_RCAccessMode::eType access_mode) FINAL;
   ~ResourceAllocationManagerImpl();
 
   void ForceAcquireResource(const std::string& module_type,
@@ -41,7 +42,7 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
   typedef std::map<uint32_t, std::vector<std::string> > RejectedResources;
   RejectedResources rejected_resources_for_application_;
 
-  AccessMode::eType current_access_mode_;
+  hmi_apis::Common_RCAccessMode::eType current_access_mode_;
   AskDriverCallBackPtr active_call_back_;
   RemotePluginInterface& rc_plugin_;
 };

--- a/src/components/remote_control/src/commands/base_command_notification.cc
+++ b/src/components/remote_control/src/commands/base_command_notification.cc
@@ -140,6 +140,10 @@ std::string BaseCommandNotification::ModuleType(const Json::Value& message) {
   return "";
 }
 
+bool BaseCommandNotification::Validate() {
+  return true;
+}
+
 std::vector<std::string> BaseCommandNotification::ControlData(
     const Json::Value& message) {
   return std::vector<std::string>();

--- a/src/components/remote_control/src/commands/base_command_request.cc
+++ b/src/components/remote_control/src/commands/base_command_request.cc
@@ -197,7 +197,7 @@ void BaseCommandRequest::SendMessageToHMI(
     }
     case AcquireResult::ASK_DRIVER: {
       ResourceAllocationManager& resource_manager =
-          rc_module_.resource_allocator_manager();
+          rc_module_.resource_allocation_manager();
       AskDriverCallBackPtr callback(
           new OnDriverAnswerCallback(message_to_send,
                                      resource_manager,

--- a/src/components/remote_control/src/commands/button_press_request.cc
+++ b/src/components/remote_control/src/commands/button_press_request.cc
@@ -104,7 +104,7 @@ void ButtonPressRequest::Execute() {
 AcquireResult::eType ButtonPressRequest::AcquireResource(
     const Json::Value& message) {
   ResourceAllocationManager& allocation_manager =
-      rc_module_.resource_allocator_manager();
+      rc_module_.resource_allocation_manager();
   const std::string& module_type = ModuleType(message);
   const uint32_t app_id = app()->app_id();
   return allocation_manager.AcquireResource(module_type, app_id);

--- a/src/components/remote_control/src/commands/on_remote_control_settings_notification.cc
+++ b/src/components/remote_control/src/commands/on_remote_control_settings_notification.cc
@@ -1,0 +1,106 @@
+/*
+ Copyright (c) 2017, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "remote_control/commands/on_remote_control_settings_notification.h"
+#include <algorithm>
+#include <vector>
+#include "json/json.h"
+#include "remote_control/rc_module_constants.h"
+#include "remote_control/message_helper.h"
+#include "remote_control/remote_control_plugin.h"
+#include "remote_control/rc_app_extension.h"
+#include "functional_module/function_ids.h"
+
+namespace remote_control {
+
+namespace commands {
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "OnRemoteControlSettingsNotification");
+
+OnRemoteControlSettingsNotification::OnRemoteControlSettingsNotification(
+    const application_manager::MessagePtr& message,
+    RemotePluginInterface& rc_module)
+    : BaseCommandNotification(message, rc_module) {}
+
+void UnsubscribeFromInteriorVehicleDataForAllModules(
+    RCAppExtensionPtr extension) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const Json::Value climate =
+      MessageHelper::StringToValue(enums_value::kClimate);
+  extension->UnsubscribeFromInteriorVehicleData(climate);
+  const Json::Value radio = MessageHelper::StringToValue(enums_value::kRadio);
+  extension->UnsubscribeFromInteriorVehicleData(radio);
+}
+
+void OnRemoteControlSettingsNotification::DisallowRCFunctionality() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  typedef std::vector<application_manager::ApplicationSharedPtr> Apps;
+  Apps apps = service_->GetApplications(rc_module_.GetModuleID());
+  for (Apps::iterator it = apps.begin(); it != apps.end(); ++it) {
+    application_manager::ApplicationSharedPtr app = *it;
+    DCHECK(app);
+    service_->ChangeNotifyHMILevel(app, mobile_apis::HMILevel::eType::HMI_NONE);
+
+    const RCAppExtensionPtr extension =
+        application_manager::AppExtensionPtr::static_pointer_cast<
+            RCAppExtension>(app->QueryInterface(rc_module_.GetModuleID()));
+    if (extension) {
+      UnsubscribeFromInteriorVehicleDataForAllModules(extension);
+    }
+  }
+}
+
+void OnRemoteControlSettingsNotification::Execute() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  application_manager::MessagePtr msg = message();
+  const Json::Value value = MessageHelper::StringToValue(msg->json_message());
+
+  const bool is_allowed = value.get(message_params::kAllowed, true).asBool();
+  if (is_allowed) {
+    const std::string access_mode =
+        value.get(message_params::kAccessMode, enums_value::kAutoAllow)
+            .asString();
+
+    const hmi_apis::Common_RCAccessMode::eType access_mode_ =
+        MessageHelper::AccessModeFromString(access_mode);
+    ResourceAllocationManager& allocation_manager =
+        rc_module_.resource_allocation_manager();
+    allocation_manager.SetAccessMode(access_mode_);
+  } else {
+    DisallowRCFunctionality();
+  }
+}
+
+}  // namespace commands
+
+}  // namespace remote_control

--- a/src/components/remote_control/src/commands/set_interior_vehicle_data_request.cc
+++ b/src/components/remote_control/src/commands/set_interior_vehicle_data_request.cc
@@ -116,7 +116,7 @@ void SetInteriorVehicleDataRequest::Execute() {
 
 AcquireResult::eType SetInteriorVehicleDataRequest::AcquireResource(
     const Json::Value& message) {
-  return rc_module_.resource_allocator_manager().AcquireResource(
+  return rc_module_.resource_allocation_manager().AcquireResource(
       ModuleType(message), app()->app_id());
 }
 

--- a/src/components/remote_control/src/message_helper.cc
+++ b/src/components/remote_control/src/message_helper.cc
@@ -36,32 +36,34 @@
 #include "utils/make_shared.h"
 
 namespace remote_control {
-using functional_modules::MobileFunctionID;
+using functional_modules::RCFunctionID;
 namespace {
-std::map<MobileFunctionID, std::string> GenerateAPINames() {
-  std::map<MobileFunctionID, std::string> result;
-  result.insert(std::make_pair<MobileFunctionID, std::string>(
-      MobileFunctionID::BUTTON_PRESS, "ButtonPress"));
-  result.insert(std::make_pair<MobileFunctionID, std::string>(
-      MobileFunctionID::GET_INTERIOR_VEHICLE_DATA, "GetInteriorVehicleData"));
-  result.insert(std::make_pair<MobileFunctionID, std::string>(
-      MobileFunctionID::SET_INTERIOR_VEHICLE_DATA, "SetInteriorVehicleData"));
-  result.insert(std::make_pair<MobileFunctionID, std::string>(
-      MobileFunctionID::ON_INTERIOR_VEHICLE_DATA, "OnInteriorVehicleData"));
+std::map<RCFunctionID, std::string> GenerateAPINames() {
+  std::map<RCFunctionID, std::string> result;
+  result.insert(std::make_pair<RCFunctionID, std::string>(
+      RCFunctionID::BUTTON_PRESS, "ButtonPress"));
+  result.insert(std::make_pair<RCFunctionID, std::string>(
+      RCFunctionID::GET_INTERIOR_VEHICLE_DATA, "GetInteriorVehicleData"));
+  result.insert(std::make_pair<RCFunctionID, std::string>(
+      RCFunctionID::SET_INTERIOR_VEHICLE_DATA, "SetInteriorVehicleData"));
+  result.insert(std::make_pair<RCFunctionID, std::string>(
+      RCFunctionID::ON_INTERIOR_VEHICLE_DATA, "OnInteriorVehicleData"));
+  result.insert(std::make_pair<RCFunctionID, std::string>(
+      RCFunctionID::ON_REMOTE_CONTROL_SETTINGS, "OnRemoteControlSettingd"));
   return result;
 }
 }
 
 uint32_t MessageHelper::next_correlation_id_ = 1;
-const std::map<MobileFunctionID, std::string> MessageHelper::kMobileAPINames =
+const std::map<RCFunctionID, std::string> MessageHelper::kMobileAPINames =
     GenerateAPINames();
 
 uint32_t MessageHelper::GetNextRCCorrelationID() {
   return next_correlation_id_++;
 }
 
-const std::string MessageHelper::GetMobileAPIName(MobileFunctionID func_id) {
-  std::map<MobileFunctionID, std::string>::const_iterator it =
+const std::string MessageHelper::GetMobileAPIName(RCFunctionID func_id) {
+  std::map<RCFunctionID, std::string>::const_iterator it =
       kMobileAPINames.find(func_id);
   if (kMobileAPINames.end() != it) {
     return it->second;
@@ -136,6 +138,20 @@ application_manager::MessagePtr MessageHelper::CreateHmiRequest(
   message_to_send->set_message_type(application_manager::MessageType::kRequest);
 
   return message_to_send;
+}
+
+hmi_apis::Common_RCAccessMode::eType MessageHelper::AccessModeFromString(
+    const std::string& access_mode) {
+  if (enums_value::kAutoAllow == access_mode) {
+    return hmi_apis::Common_RCAccessMode::AUTO_ALLOW;
+  }
+  if (enums_value::kAutoDeny == access_mode) {
+    return hmi_apis::Common_RCAccessMode::AUTO_DENY;
+  }
+  if (enums_value::kAskDriver == access_mode) {
+    return hmi_apis::Common_RCAccessMode::ASK_DRIVER;
+  }
+  return hmi_apis::Common_RCAccessMode::INVALID_ENUM;
 }
 
 }  // namespace remote_control

--- a/src/components/remote_control/src/rc_command_factory.cc
+++ b/src/components/remote_control/src/rc_command_factory.cc
@@ -37,35 +37,40 @@
 #include "remote_control/commands/get_interior_vehicle_data_request.h"
 #include "remote_control/commands/set_interior_vehicle_data_request.h"
 #include "remote_control/commands/button_press_request.h"
-
 #include "remote_control/commands/on_interior_vehicle_data_notification.h"
+#include "remote_control/commands/on_remote_control_settings_notification.h"
 
 namespace remote_control {
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "RemoteControl")
 
-using functional_modules::MobileFunctionID;
+using functional_modules::RCFunctionID;
 
 utils::SharedPtr<commands::Command> RCCommandFactory::CreateCommand(
     const application_manager::MessagePtr& msg,
     RemotePluginInterface& rc_module) {
   switch (msg->function_id()) {
-    case MobileFunctionID::GET_INTERIOR_VEHICLE_DATA: {
+    case RCFunctionID::GET_INTERIOR_VEHICLE_DATA: {
       return utils::MakeShared<commands::GetInteriorVehicleDataRequest>(
           msg, rc_module);
       break;
     }
-    case MobileFunctionID::SET_INTERIOR_VEHICLE_DATA: {
+    case RCFunctionID::SET_INTERIOR_VEHICLE_DATA: {
       return utils::MakeShared<commands::SetInteriorVehicleDataRequest>(
           msg, rc_module);
       break;
     }
-    case MobileFunctionID::BUTTON_PRESS: {
+    case RCFunctionID::BUTTON_PRESS: {
       return utils::MakeShared<commands::ButtonPressRequest>(msg, rc_module);
       break;
     }
-    case MobileFunctionID::ON_INTERIOR_VEHICLE_DATA: {
+    case RCFunctionID::ON_INTERIOR_VEHICLE_DATA: {
       return utils::MakeShared<commands::OnInteriorVehicleDataNotification>(
+          msg, rc_module);
+      break;
+    }
+    case RCFunctionID::ON_REMOTE_CONTROL_SETTINGS: {
+      return utils::MakeShared<commands::OnRemoteControlSettingsNotification>(
           msg, rc_module);
       break;
     }

--- a/src/components/remote_control/src/remote_control_plugin.cc
+++ b/src/components/remote_control/src/remote_control_plugin.cc
@@ -49,7 +49,7 @@ namespace remote_control {
 using functional_modules::ProcessResult;
 using functional_modules::GenericModule;
 using functional_modules::PluginInfo;
-using functional_modules::MobileFunctionID;
+using functional_modules::RCFunctionID;
 namespace hmi_api = functional_modules::hmi_api;
 
 using namespace json_keys;
@@ -66,19 +66,20 @@ RemoteControlPlugin::RemoteControlPlugin()
 }
 
 void RemoteControlPlugin::SubscribeOnFunctions() {
-  plugin_info_.mobile_function_list.push_back(MobileFunctionID::BUTTON_PRESS);
-  plugin_info_.mobile_function_list.push_back(
-      MobileFunctionID::GET_INTERIOR_VEHICLE_DATA);
-  plugin_info_.mobile_function_list.push_back(
-      MobileFunctionID::SET_INTERIOR_VEHICLE_DATA);
-  plugin_info_.mobile_function_list.push_back(
-      MobileFunctionID::ON_INTERIOR_VEHICLE_DATA);
+  plugin_info_.rc_function_list.push_back(RCFunctionID::BUTTON_PRESS);
+  plugin_info_.rc_function_list.push_back(
+      RCFunctionID::GET_INTERIOR_VEHICLE_DATA);
+  plugin_info_.rc_function_list.push_back(
+      RCFunctionID::SET_INTERIOR_VEHICLE_DATA);
+  plugin_info_.rc_function_list.push_back(
+      RCFunctionID::ON_INTERIOR_VEHICLE_DATA);
 
   plugin_info_.hmi_function_list.push_back(hmi_api::get_interior_vehicle_data);
   plugin_info_.hmi_function_list.push_back(hmi_api::set_interior_vehicle_data);
   plugin_info_.hmi_function_list.push_back(hmi_api::on_interior_vehicle_data);
   plugin_info_.hmi_function_list.push_back(hmi_api::button_press);
   plugin_info_.hmi_function_list.push_back(hmi_api::get_user_consent);
+  plugin_info_.hmi_function_list.push_back(hmi_api::on_remote_control_settings);
 }
 
 RemoteControlPlugin::~RemoteControlPlugin() {
@@ -141,7 +142,7 @@ ProcessResult RemoteControlPlugin::ProcessMessage(
   DCHECK_OR_RETURN(msg, ProcessResult::FAILED);
 
   const std::string& function_name = MessageHelper::GetMobileAPIName(
-      static_cast<functional_modules::MobileFunctionID>(msg->function_id()));
+      static_cast<functional_modules::RCFunctionID>(msg->function_id()));
 
   LOG4CXX_DEBUG(logger_, "Function name to set : " << function_name);
   msg->set_function_name(function_name);
@@ -187,6 +188,9 @@ ProcessResult RemoteControlPlugin::ProcessHMIMessage(
     case application_manager::MessageType::kNotification: {
       if (hmi_api::on_interior_vehicle_data == function_name) {
         msg->set_function_id(functional_modules::ON_INTERIOR_VEHICLE_DATA);
+      }
+      if (hmi_api::on_remote_control_settings == function_name) {
+        msg->set_function_id(functional_modules::ON_REMOTE_CONTROL_SETTINGS);
       }
       const application_manager::MessageValidationResult validation_result =
           service()->ValidateMessageBySchema(*msg);
@@ -352,7 +356,7 @@ RCEventDispatcher& RemoteControlPlugin::event_dispatcher() {
   return event_dispatcher_;
 }
 
-ResourceAllocationManager& RemoteControlPlugin::resource_allocator_manager() {
+ResourceAllocationManager& RemoteControlPlugin::resource_allocation_manager() {
   return resource_allocation_manager_;
 }
 

--- a/src/components/remote_control/src/resource_allocation_manager_impl.cc
+++ b/src/components/remote_control/src/resource_allocation_manager_impl.cc
@@ -13,7 +13,7 @@ CREATE_LOGGERPTR_GLOBAL(logger_, "RemoteControlModule")
 
 ResourceAllocationManagerImpl::ResourceAllocationManagerImpl(
     RemotePluginInterface& rc_plugin)
-    : current_access_mode_(AccessMode::AUTO_ALLOW)
+    : current_access_mode_(hmi_apis::Common_RCAccessMode::AUTO_ALLOW)
     , active_call_back_()
     , rc_plugin_(rc_plugin) {}
 
@@ -63,21 +63,21 @@ AcquireResult::eType ResourceAllocationManagerImpl::AcquireResource(
   }
 
   switch (current_access_mode_) {
-    case AccessMode::AUTO_DENY: {
+    case hmi_apis::Common_RCAccessMode::AUTO_DENY: {
       LOG4CXX_DEBUG(logger_,
                     "Current access_mode is AUTO_DENY. "
                         << "App: " << app_id << " is disallowed to acquire "
                         << module_type);
       return AcquireResult::IN_USE;
     }
-    case AccessMode::ASK_DRIVER: {
+    case hmi_apis::Common_RCAccessMode::ASK_DRIVER: {
       LOG4CXX_DEBUG(logger_,
                     "Current access_mode is ASK_DRIVER. "
                     "Driver confirmation is required for app: "
                         << app_id << " to acquire " << module_type);
       return AcquireResult::ASK_DRIVER;
     }
-    case AccessMode::AUTO_ALLOW: {
+    case hmi_apis::Common_RCAccessMode::AUTO_ALLOW: {
       LOG4CXX_DEBUG(logger_,
                     "Current access_mode is AUTO_ALLOW. "
                         << "App: " << app_id << " is allowed to acquire "
@@ -90,7 +90,7 @@ AcquireResult::eType ResourceAllocationManagerImpl::AcquireResource(
 }
 
 void ResourceAllocationManagerImpl::SetAccessMode(
-    const AccessMode::eType access_mode) {
+    const hmi_apis::Common_RCAccessMode::eType access_mode) {
   current_access_mode_ = access_mode;
 }
 

--- a/src/components/remote_control/test/commands/button_press_request_test.cc
+++ b/src/components/remote_control/test/commands/button_press_request_test.cc
@@ -46,7 +46,7 @@
 #include "utils/shared_ptr.h"
 #include "utils/make_shared.h"
 
-using functional_modules::MobileFunctionID;
+using functional_modules::RCFunctionID;
 using application_manager::ServicePtr;
 
 using application_manager::MockService;
@@ -96,7 +96,7 @@ class ButtonPressRequestTest : public ::testing::Test {
       , rc_app_extention_(
             utils::MakeShared<remote_control::RCAppExtension>(kModuleId)) {
     ON_CALL(mock_module_, service()).WillByDefault(Return(mock_service_));
-    ON_CALL(mock_module_, resource_allocator_manager())
+    ON_CALL(mock_module_, resource_allocation_manager())
         .WillByDefault(ReturnRef(mock_allocation_manager_));
     ON_CALL(*mock_service_, GetApplication(kAppId))
         .WillByDefault(Return(mock_app_));
@@ -114,7 +114,7 @@ class ButtonPressRequestTest : public ::testing::Test {
   application_manager::MessagePtr CreateBasicMessage() {
     application_manager::MessagePtr message = utils::MakeShared<Message>(
         MessagePriority::FromServiceType(protocol_handler::ServiceType::kRpc));
-    message->set_function_id(MobileFunctionID::BUTTON_PRESS);
+    message->set_function_id(RCFunctionID::BUTTON_PRESS);
     message->set_function_name(
         MessageHelper::GetMobileAPIName(functional_modules::BUTTON_PRESS));
     message->set_connection_key(kAppId);

--- a/src/components/remote_control/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/remote_control/test/commands/get_interior_vehicle_data_request_test.cc
@@ -45,7 +45,7 @@
 #include "utils/shared_ptr.h"
 #include "utils/make_shared.h"
 
-using functional_modules::MobileFunctionID;
+using functional_modules::RCFunctionID;
 using application_manager::ServicePtr;
 
 using application_manager::MockService;
@@ -128,7 +128,7 @@ class GetInteriorVehicleDataRequestTest : public ::testing::Test {
     application_manager::MessagePtr message = utils::MakeShared<Message>(
         MessagePriority::FromServiceType(protocol_handler::ServiceType::kRpc));
     message->set_connection_key(kConnectionKey);
-    message->set_function_id(MobileFunctionID::GET_INTERIOR_VEHICLE_DATA);
+    message->set_function_id(RCFunctionID::GET_INTERIOR_VEHICLE_DATA);
     message->set_function_name("GetInteriorVehicleData");
     return message;
   }

--- a/src/components/remote_control/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/remote_control/test/commands/get_interior_vehicle_data_request_test.cc
@@ -148,7 +148,7 @@ TEST_F(GetInteriorVehicleDataRequestTest,
   application_manager::MessagePtr mobile_message = CreateBasicMessage();
   mobile_message->set_json_message(kValidMobileRequest);
   // Expectations
-  EXPECT_CALL(mock_module_, service()).WillOnce(Return(mock_service_));
+  EXPECT_CALL(mock_module_, service()).Times(2).WillOnce(Return(mock_service_));
   EXPECT_CALL(*mock_service_, GetApplication(mobile_message->connection_key()))
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(*mock_service_, ValidateMessageBySchema(*mobile_message))

--- a/src/components/remote_control/test/commands/on_interior_vehicle_data_notification_test.cc
+++ b/src/components/remote_control/test/commands/on_interior_vehicle_data_notification_test.cc
@@ -45,7 +45,7 @@
 #include "utils/shared_ptr.h"
 #include "utils/make_shared.h"
 
-using functional_modules::MobileFunctionID;
+using functional_modules::RCFunctionID;
 using application_manager::ServicePtr;
 
 using application_manager::MockService;
@@ -98,7 +98,7 @@ class OnInteriorVehicleDataNotificationTest : public ::testing::Test {
   application_manager::MessagePtr CreateBasicMessage() {
     application_manager::MessagePtr message = utils::MakeShared<Message>(
         MessagePriority::FromServiceType(protocol_handler::ServiceType::kRpc));
-    message->set_function_id(MobileFunctionID::ON_INTERIOR_VEHICLE_DATA);
+    message->set_function_id(RCFunctionID::ON_INTERIOR_VEHICLE_DATA);
     message->set_function_name("OnInteriorVehicleData");
     message->set_json_message(kJson);
     return message;

--- a/src/components/remote_control/test/include/mock_remote_control_plugin.h
+++ b/src/components/remote_control/test/include/mock_remote_control_plugin.h
@@ -43,7 +43,7 @@ class MockRemotePluginInterface : public remote_control::RemotePluginInterface {
   MOCK_METHOD0(RemoveAppExtensions, void());
   MOCK_METHOD0(service, application_manager::ServicePtr());
   MOCK_CONST_METHOD0(GetModuleID, functional_modules::ModuleID());
-  MOCK_METHOD0(resource_allocator_manager,
+  MOCK_METHOD0(resource_allocation_manager,
                remote_control::ResourceAllocationManager&());
 };
 

--- a/src/components/remote_control/test/include/mock_resource_allocation_manager.h
+++ b/src/components/remote_control/test/include/mock_resource_allocation_manager.h
@@ -30,6 +30,8 @@ class MockResourceAllocationManager
                void(const std::string& module_type,
                     const uint32_t app_id,
                     remote_control::AskDriverCallBackPtr callback));
+  MOCK_METHOD1(SetAccessMode,
+               void(const hmi_apis::Common_RCAccessMode::eType access_mode));
 };
 
 }  // namespace remote_control_test

--- a/src/components/remote_control/test/src/rc_module_test.cc
+++ b/src/components/remote_control/test/src/rc_module_test.cc
@@ -44,7 +44,7 @@
 
 using functional_modules::PluginInfo;
 using functional_modules::ProcessResult;
-using functional_modules::MobileFunctionID;
+using functional_modules::RCFunctionID;
 using application_manager::ServicePtr;
 
 using application_manager::MockService;
@@ -126,7 +126,7 @@ TEST_F(RCModuleTest, ProcessMessageWrongMessage) {
 }
 
 TEST_F(RCModuleTest, ProcessMessageEmptyapps_List) {
-  message_->set_function_id(MobileFunctionID::ON_INTERIOR_VEHICLE_DATA);
+  message_->set_function_id(RCFunctionID::ON_INTERIOR_VEHICLE_DATA);
   message_->set_function_name("OnInteriorVehicleData");
 
   std::string json =
@@ -145,7 +145,7 @@ TEST_F(RCModuleTest, ProcessMessageEmptyapps_List) {
 }
 
 TEST_F(RCModuleTest, ProcessMessagePass) {
-  message_->set_function_id(MobileFunctionID::ON_INTERIOR_VEHICLE_DATA);
+  message_->set_function_id(RCFunctionID::ON_INTERIOR_VEHICLE_DATA);
 
   std::string json =
       "{ \"jsonrpc\": \"2.0\",\"method\": \"RC.OnInteriorVehicleData\",\


### PR DESCRIPTION
[#1668](https://github.com/smartdevicelink/sdl_core/issues/1668)
- Implement OnRemoteControlSettings notification logic that provide or deny access to RC_module;
- Rename MobileFunctionID to RCFunctionID;
- Delete AccessMode enum and replace it use Common_RCAccessMode::eType from HMI_API 