### PR TITLE
Fix Response to mobile in case of wrong response from hmi

### DIFF
--- a/src/components/remote_control/src/commands/set_interior_vehicle_data_request.cc
+++ b/src/components/remote_control/src/commands/set_interior_vehicle_data_request.cc
@@ -191,10 +191,13 @@ void SetInteriorVehicleDataRequest::OnEvent(
   std::string result_code;
   std::string info;
 
-  const bool is_response_successful = ParseResultCode(value, result_code, info);
+  const bool is_response_successful =
+      validate_result && ParseResultCode(value, result_code, info);
 
   if (is_response_successful) {
     response_params_[kModuleData] = value[kResult][kModuleData];
+  } else if (remote_control::result_codes::kReadOnly != result_code) {
+    result_code = result_codes::kGenericError;
   }
   SendResponse(is_response_successful, result_code.c_str(), info);
 }


### PR DESCRIPTION
Fixed response to mobile
In case of wrong response from hmi(invalid json, missing mandatory param etc.) - SDL must send GENERIC_ERROR to mobile. 
The Only Exception: HMI sends response with result code: `READ_ONLY` - SDL must forward this code to mobile app.