### PR TITLE
Fixes simultaneous processing of RC RPCs

### DIFF
--- a/src/components/remote_control/include/remote_control/commands/base_command_request.h
+++ b/src/components/remote_control/include/remote_control/commands/base_command_request.h
@@ -120,6 +120,29 @@ class BaseCommandRequest
   }
 
   /**
+   * @brief IsResourceFree check resource state
+   * This is default implementation which has to be redefined for RPCs which
+   * need to manager the resources
+   * @param module_type Resource name
+   * @return True if free, otherwise - false
+   */
+  virtual bool IsResourceFree(const std::string& module_type) const {
+    UNUSED(module_type);
+    return true;
+  }
+
+  /**
+   * @brief SetResourceState changes state of resource
+   * This is default implementation which has to be redefined for RPCs which
+   * need to manager the resources
+   * @param state State to set for resource
+   */
+  virtual void SetResourceState(const Json::Value&,
+                                const ResourceState::eType state) {
+    UNUSED(state);
+  }
+
+  /**
    * @brief Get extension for specified application. If extension doesn't exist,
    * it will be created
    * @param app pointer to application

--- a/src/components/remote_control/include/remote_control/commands/base_command_request.h
+++ b/src/components/remote_control/include/remote_control/commands/base_command_request.h
@@ -122,7 +122,7 @@ class BaseCommandRequest
   /**
    * @brief IsResourceFree check resource state
    * This is default implementation which has to be redefined for RPCs which
-   * need to manager the resources
+   * need to manage the resources
    * @param module_type Resource name
    * @return True if free, otherwise - false
    */
@@ -134,13 +134,12 @@ class BaseCommandRequest
   /**
    * @brief SetResourceState changes state of resource
    * This is default implementation which has to be redefined for RPCs which
-   * need to manager the resources
-   * @param state State to set for resource
+   * need to manage the resources
+   * @param Message containing type of module to extract
+   * @param State to set for resource
    */
   virtual void SetResourceState(const Json::Value&,
-                                const ResourceState::eType state) {
-    UNUSED(state);
-  }
+                                const ResourceState::eType) {}
 
   /**
    * @brief Get extension for specified application. If extension doesn't exist,

--- a/src/components/remote_control/include/remote_control/commands/button_press_request.h
+++ b/src/components/remote_control/include/remote_control/commands/button_press_request.h
@@ -58,8 +58,27 @@ class ButtonPressRequest : public BaseCommandRequest {
    */
   void Execute() FINAL;
 
+  /**
+   * @brief AcquireResource Tries to acquire specific resource
+   * @param message Incoming message containg the resource name
+   * @return Acquire result
+   */
   AcquireResult::eType AcquireResource(
       const Json::Value& message) OVERRIDE FINAL;
+
+  /**
+   * @brief IsResourceFree check resource state
+   * @param module_type Resource name
+   * @return True if free, otherwise - false
+   */
+  bool IsResourceFree(const std::string& module_type) const OVERRIDE FINAL;
+
+  /**
+   * @brief SetResourceState changes state of resource
+   * @param state State to set for resource
+   */
+  void SetResourceState(const Json::Value& message,
+                        const ResourceState::eType state) OVERRIDE FINAL;
 
   /**
    * @brief Interface method that is called whenever new event received

--- a/src/components/remote_control/include/remote_control/commands/button_press_request.h
+++ b/src/components/remote_control/include/remote_control/commands/button_press_request.h
@@ -71,14 +71,14 @@ class ButtonPressRequest : public BaseCommandRequest {
    * @param module_type Resource name
    * @return True if free, otherwise - false
    */
-  bool IsResourceFree(const std::string& module_type) const OVERRIDE FINAL;
+  bool IsResourceFree(const std::string& module_type) const FINAL;
 
   /**
    * @brief SetResourceState changes state of resource
    * @param state State to set for resource
    */
   void SetResourceState(const Json::Value& message,
-                        const ResourceState::eType state) OVERRIDE FINAL;
+                        const ResourceState::eType state) FINAL;
 
   /**
    * @brief Interface method that is called whenever new event received

--- a/src/components/remote_control/include/remote_control/commands/set_interior_vehicle_data_request.h
+++ b/src/components/remote_control/include/remote_control/commands/set_interior_vehicle_data_request.h
@@ -73,14 +73,14 @@ class SetInteriorVehicleDataRequest : public BaseCommandRequest {
    * @param module_type Resource name
    * @return True if free, otherwise - false
    */
-  bool IsResourceFree(const std::string& module_type) const OVERRIDE FINAL;
+  bool IsResourceFree(const std::string& module_type) const FINAL;
 
   /**
    * @brief SetResourceState changes state of resource
    * @param state State to set for resource
    */
   void SetResourceState(const Json::Value& message,
-                        const ResourceState::eType state) OVERRIDE FINAL;
+                        const ResourceState::eType state) FINAL;
 
   /**
    * @brief Interface method that is called whenever new event received
@@ -88,7 +88,7 @@ class SetInteriorVehicleDataRequest : public BaseCommandRequest {
    * @param event The received event
    */
   void OnEvent(const rc_event_engine::Event<application_manager::MessagePtr,
-                                            std::string>& event);
+                                            std::string>& event) OVERRIDE;
 
   /**
    * @brief Method that check if READ_ONLY parameters present

--- a/src/components/remote_control/include/remote_control/commands/set_interior_vehicle_data_request.h
+++ b/src/components/remote_control/include/remote_control/commands/set_interior_vehicle_data_request.h
@@ -69,6 +69,20 @@ class SetInteriorVehicleDataRequest : public BaseCommandRequest {
       const Json::Value& message) OVERRIDE FINAL;
 
   /**
+   * @brief IsResourceFree check resource state
+   * @param module_type Resource name
+   * @return True if free, otherwise - false
+   */
+  bool IsResourceFree(const std::string& module_type) const OVERRIDE FINAL;
+
+  /**
+   * @brief SetResourceState changes state of resource
+   * @param state State to set for resource
+   */
+  void SetResourceState(const Json::Value& message,
+                        const ResourceState::eType state) OVERRIDE FINAL;
+
+  /**
    * @brief Interface method that is called whenever new event received
    *
    * @param event The received event

--- a/src/components/remote_control/include/remote_control/resource_allocation_manager.h
+++ b/src/components/remote_control/include/remote_control/resource_allocation_manager.h
@@ -23,13 +23,6 @@ enum eType { FREE = 0, BUSY };
 }
 
 /**
- * Enum contains list of access modes
- */
-namespace AccessMode {
-enum eType { AUTO_ALLOW = 0, AUTO_DENY, ASK_DRIVER };
-}  // AccessMode
-
-/**
  * @brief The AskDriverCallBack class callback for GetInteriourConsent response
  */
 class AskDriverCallBack

--- a/src/components/remote_control/include/remote_control/resource_allocation_manager.h
+++ b/src/components/remote_control/include/remote_control/resource_allocation_manager.h
@@ -16,6 +16,20 @@ enum eType { ALLOWED = 0, IN_USE, ASK_DRIVER, REJECTED };
 }
 
 /**
+ * Defines states of acquired resource
+ */
+namespace ResourceState {
+enum eType { FREE = 0, BUSY };
+}
+
+/**
+ * Enum contains list of access modes
+ */
+namespace AccessMode {
+enum eType { AUTO_ALLOW = 0, AUTO_DENY, ASK_DRIVER };
+}  // AccessMode
+
+/**
  * @brief The AskDriverCallBack class callback for GetInteriourConsent response
  */
 class AskDriverCallBack
@@ -39,6 +53,24 @@ class ResourceAllocationManager {
    */
   virtual AcquireResult::eType AcquireResource(const std::string& module_type,
                                                const uint32_t app_id) = 0;
+
+  /**
+   * @brief SetResourceState changes resource state. Resource must be acquired
+   * beforehand.
+   * @param module_type Resource to change its state
+   * @param app_id Application aquired resource before
+   * @param state State to set for resource
+   */
+  virtual void SetResourceState(const std::string& module_type,
+                                const uint32_t app_id,
+                                const ResourceState::eType state) = 0;
+
+  /**
+   * @brief IsResourceFree check resource state
+   * @param module_type Resource name
+   * @return True if free, otherwise - false
+   */
+  virtual bool IsResourceFree(const std::string& module_type) const = 0;
 
   /**
    * @brief AcquireResource forces acquiring resource by application

--- a/src/components/remote_control/include/remote_control/resource_allocation_manager_impl.h
+++ b/src/components/remote_control/include/remote_control/resource_allocation_manager_impl.h
@@ -17,9 +17,9 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
 
   void SetResourceState(const std::string& module_type,
                         const uint32_t app_id,
-                        const ResourceState::eType state) OVERRIDE FINAL;
+                        const ResourceState::eType state) FINAL;
 
-  bool IsResourceFree(const std::string& module_type) const OVERRIDE FINAL;
+  bool IsResourceFree(const std::string& module_type) const FINAL;
 
   void AskDriver(const std::string& module_type,
                  const uint32_t hmi_app_id,

--- a/src/components/remote_control/include/remote_control/resource_allocation_manager_impl.h
+++ b/src/components/remote_control/include/remote_control/resource_allocation_manager_impl.h
@@ -14,6 +14,13 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
 
   AcquireResult::eType AcquireResource(const std::string& module_type,
                                        const uint32_t app_id) OVERRIDE FINAL;
+
+  void SetResourceState(const std::string& module_type,
+                        const uint32_t app_id,
+                        const ResourceState::eType state) OVERRIDE FINAL;
+
+  bool IsResourceFree(const std::string& module_type) const OVERRIDE FINAL;
+
   void AskDriver(const std::string& module_type,
                  const uint32_t hmi_app_id,
                  AskDriverCallBackPtr callback) OVERRIDE FINAL;
@@ -31,8 +38,19 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
  private:
   bool IsModuleTypeRejected(const std::string& module_type,
                             const uint32_t app_id);
+
+  /**
+   * @brief AllocatedResources contains link between resource and application
+   * owning that resource
+   */
   typedef std::map<std::string, uint32_t> AllocatedResources;
-  std::map<std::string, uint32_t> allocated_resources_;
+  AllocatedResources allocated_resources_;
+
+  /**
+   * @brief ResourcesState contains states of ALLOCATED resources
+   */
+  typedef std::map<std::string, ResourceState::eType> ResourcesState;
+  ResourcesState resources_state_;
 
   /**
    * @brief RejectedResources type for connecting list of resources rejected by

--- a/src/components/remote_control/src/commands/button_press_request.cc
+++ b/src/components/remote_control/src/commands/button_press_request.cc
@@ -110,6 +110,20 @@ AcquireResult::eType ButtonPressRequest::AcquireResource(
   return allocation_manager.AcquireResource(module_type, app_id);
 }
 
+bool ButtonPressRequest::IsResourceFree(const std::string& module_type) const {
+  return rc_module_.resource_allocation_manager().IsResourceFree(module_type);
+}
+
+void ButtonPressRequest::SetResourceState(const Json::Value& message,
+                                          const ResourceState::eType state) {
+  const std::string& module_type = ModuleType(message);
+  const uint32_t app_id = app()->app_id();
+
+  ResourceAllocationManager& allocation_manager =
+      rc_module_.resource_allocation_manager();
+  allocation_manager.SetResourceState(module_type, app_id, state);
+}
+
 void ButtonPressRequest::OnEvent(
     const rc_event_engine::Event<application_manager::MessagePtr, std::string>&
         event) {

--- a/src/components/remote_control/src/commands/set_interior_vehicle_data_request.cc
+++ b/src/components/remote_control/src/commands/set_interior_vehicle_data_request.cc
@@ -120,6 +120,22 @@ AcquireResult::eType SetInteriorVehicleDataRequest::AcquireResource(
       ModuleType(message), app()->app_id());
 }
 
+bool SetInteriorVehicleDataRequest::IsResourceFree(
+    const std::string& module_type) const {
+  return rc_module_.resource_allocation_manager().IsResourceFree(module_type);
+}
+
+void SetInteriorVehicleDataRequest::SetResourceState(
+    const Json::Value& message, const ResourceState::eType state) {
+  const std::string& module_type = ModuleType(message);
+  const uint32_t app_id = app()->app_id();
+
+  ResourceAllocationManager& allocation_manager =
+      rc_module_.resource_allocation_manager();
+
+  allocation_manager.SetResourceState(module_type, app_id, state);
+}
+
 bool SetInteriorVehicleDataRequest::AreReadOnlyParamsPresent(
     const Json::Value& request_params) {
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/remote_control/src/resource_allocation_manager_impl.cc
+++ b/src/components/remote_control/src/resource_allocation_manager_impl.cc
@@ -102,9 +102,11 @@ void ResourceAllocationManagerImpl::SetResourceState(
       allocated_resources_.find(module_type);
 
   DCHECK_OR_RETURN_VOID(allocated_resources_.end() != allocated_it)
-  LOG4CXX_DEBUG(logger_, "Resource " << module_type << " is acquired.");
-  LOG4CXX_DEBUG(logger_, "Owner application id is " << allocated_it->second);
-  LOG4CXX_DEBUG(logger_, "Changing application id is " << app_id);
+  LOG4CXX_DEBUG(logger_,
+                "Resource " << module_type << " is acquired."
+                            << " Owner application id is "
+                            << allocated_it->second
+                            << " Changing application id is " << app_id);
   DCHECK_OR_RETURN_VOID(app_id == allocated_it->second);
 
   resources_state_[module_type] = state;
@@ -119,7 +121,6 @@ bool ResourceAllocationManagerImpl::IsResourceFree(
 
   if (resources_state_.end() == resource) {
     LOG4CXX_DEBUG(logger_, "Resource " << module_type << " is free.");
-
     return true;
   }
 

--- a/src/components/remote_control/src/resource_allocation_manager_impl.cc
+++ b/src/components/remote_control/src/resource_allocation_manager_impl.cc
@@ -82,11 +82,51 @@ AcquireResult::eType ResourceAllocationManagerImpl::AcquireResource(
                     "Current access_mode is AUTO_ALLOW. "
                         << "App: " << app_id << " is allowed to acquire "
                         << module_type);
+
       allocated_resources_[module_type] = app_id;
       return AcquireResult::ALLOWED;
     }
     default: { DCHECK_OR_RETURN(false, AcquireResult::IN_USE); }
   }
+}
+
+void ResourceAllocationManagerImpl::SetResourceState(
+    const std::string& module_type,
+    const uint32_t app_id,
+    const ResourceState::eType state) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  LOG4CXX_DEBUG(logger_,
+                "Setting state for " << module_type << " by app_id " << app_id
+                                     << " to state " << state);
+  const AllocatedResources::const_iterator allocated_it =
+      allocated_resources_.find(module_type);
+
+  DCHECK_OR_RETURN_VOID(allocated_resources_.end() != allocated_it)
+  LOG4CXX_DEBUG(logger_, "Resource " << module_type << " is acquired.");
+  LOG4CXX_DEBUG(logger_, "Owner application id is " << allocated_it->second);
+  LOG4CXX_DEBUG(logger_, "Changing application id is " << app_id);
+  DCHECK_OR_RETURN_VOID(app_id == allocated_it->second);
+
+  resources_state_[module_type] = state;
+  LOG4CXX_DEBUG(logger_, "Resource" << module_type << " got state " << state);
+}
+
+bool ResourceAllocationManagerImpl::IsResourceFree(
+    const std::string& module_type) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const ResourcesState::const_iterator resource =
+      resources_state_.find(module_type);
+
+  if (resources_state_.end() == resource) {
+    LOG4CXX_DEBUG(logger_, "Resource " << module_type << " is free.");
+
+    return true;
+  }
+
+  LOG4CXX_DEBUG(logger_,
+                "Resource " << module_type << " state is " << resource->second);
+
+  return ResourceState::FREE == resource->second;
 }
 
 void ResourceAllocationManagerImpl::SetAccessMode(

--- a/src/components/remote_control/test/commands/button_press_request_test.cc
+++ b/src/components/remote_control/test/commands/button_press_request_test.cc
@@ -157,11 +157,20 @@ TEST_F(ButtonPressRequestTest,
   EXPECT_CALL(*mock_service_, CheckAccess(_, _, _, _))
       .WillOnce(Return(application_manager::TypeAccess::kAllowed));
   EXPECT_CALL(*mock_service_, GetNextCorrelationID()).WillOnce(Return(1));
+
+  const std::string resource = "CLIMATE";
+
+  EXPECT_CALL(mock_allocation_manager_, IsResourceFree(resource))
+      .WillOnce(Return(true));
+  EXPECT_CALL(mock_allocation_manager_, AcquireResource(resource, kAppId))
+      .WillOnce(Return(remote_control::AcquireResult::ALLOWED));
+  EXPECT_CALL(
+      mock_allocation_manager_,
+      SetResourceState(resource, kAppId, remote_control::ResourceState::BUSY));
+
   application_manager::MessagePtr result_msg;
   EXPECT_CALL(*mock_service_, SendMessageToHMI(_))
       .WillOnce(SaveArg<0>(&result_msg));
-  EXPECT_CALL(mock_allocation_manager_, AcquireResource("CLIMATE", kAppId))
-      .WillOnce(Return(remote_control::AcquireResult::ALLOWED));
 
   // Act
   remote_control::request_controller::MobileRequestPtr command =

--- a/src/components/remote_control/test/commands/set_interior_vehicle_data_request_test.cc
+++ b/src/components/remote_control/test/commands/set_interior_vehicle_data_request_test.cc
@@ -177,11 +177,19 @@ TEST_F(SetInteriorVehicleDataRequestTest,
   EXPECT_CALL(*mock_service_, GetNextCorrelationID())
       .WillOnce(Return(kCorrelationId));
 
+  const std::string resource = "CLIMATE";
+
+  EXPECT_CALL(mock_allocation_manager_, IsResourceFree(resource))
+      .WillOnce(Return(true));
+  EXPECT_CALL(mock_allocation_manager_, AcquireResource(resource, kAppId))
+      .WillOnce(Return(remote_control::AcquireResult::ALLOWED));
+  EXPECT_CALL(
+      mock_allocation_manager_,
+      SetResourceState(resource, kAppId, remote_control::ResourceState::BUSY));
+
   application_manager::MessagePtr result_msg;
   EXPECT_CALL(*mock_service_, SendMessageToHMI(_))
       .WillOnce(SaveArg<0>(&result_msg));
-  EXPECT_CALL(mock_allocation_manager_, AcquireResource("CLIMATE", kAppId))
-      .WillOnce(Return(remote_control::AcquireResult::ALLOWED));
 
   // Act
   remote_control::request_controller::MobileRequestPtr command =
@@ -237,11 +245,19 @@ TEST_F(
   EXPECT_CALL(*mock_service_, GetNextCorrelationID())
       .WillOnce(Return(kCorrelationId));
 
+  const std::string resource = "CLIMATE";
+
+  EXPECT_CALL(mock_allocation_manager_, IsResourceFree(resource))
+      .WillOnce(Return(true));
+  EXPECT_CALL(mock_allocation_manager_, AcquireResource(resource, kAppId))
+      .WillOnce(Return(remote_control::AcquireResult::ALLOWED));
+  EXPECT_CALL(
+      mock_allocation_manager_,
+      SetResourceState(resource, kAppId, remote_control::ResourceState::BUSY));
+
   application_manager::MessagePtr result_msg;
   EXPECT_CALL(*mock_service_, SendMessageToHMI(_))
       .WillOnce(SaveArg<0>(&result_msg));
-  EXPECT_CALL(mock_allocation_manager_, AcquireResource("CLIMATE", kAppId))
-      .WillOnce(Return(remote_control::AcquireResult::ALLOWED));
 
   // Act
   remote_control::request_controller::MobileRequestPtr command =

--- a/src/components/remote_control/test/include/mock_resource_allocation_manager.h
+++ b/src/components/remote_control/test/include/mock_resource_allocation_manager.h
@@ -32,6 +32,11 @@ class MockResourceAllocationManager
                     remote_control::AskDriverCallBackPtr callback));
   MOCK_METHOD1(SetAccessMode,
                void(const hmi_apis::Common_RCAccessMode::eType access_mode));
+  MOCK_METHOD3(SetResourceState,
+               void(const std::string& module_type,
+                    const uint32_t app_id,
+                    const remote_control::ResourceState::eType state));
+  MOCK_CONST_METHOD1(IsResourceFree, bool(const std::string& module_type));
 };
 
 }  // namespace remote_control_test


### PR DESCRIPTION
In case some RC request is pending and uses allocated resource (module)
another request must consider such resource as having 'busy' state and
do not try to re-acquire it. SDL must return 'in use' result in that
case.