### PR TITLE
Fix erroneous result code transferring for SetInteriorVehicleData

### DIFF
--- a/src/components/remote_control/src/commands/set_interior_vehicle_data_request.cc
+++ b/src/components/remote_control/src/commands/set_interior_vehicle_data_request.cc
@@ -207,15 +207,16 @@ void SetInteriorVehicleDataRequest::OnEvent(
   std::string result_code;
   std::string info;
 
-  const bool is_response_successful =
+  const bool success =
       validate_result && ParseResultCode(value, result_code, info);
 
-  if (is_response_successful) {
+  if (success) {
     response_params_[kModuleData] = value[kResult][kModuleData];
-  } else if (remote_control::result_codes::kReadOnly != result_code) {
+  } else if (!validate_result) {
     result_code = result_codes::kGenericError;
   }
-  SendResponse(is_response_successful, result_code.c_str(), info);
+
+  SendResponse(success, result_code.c_str(), info);
 }
 
 std::string SetInteriorVehicleDataRequest::ModuleType(


### PR DESCRIPTION
The problem was in wrong condition in if-else statement - "else" block in this statement should be executed only in case of invalid HMI response message. 
In all other cases, including `READ_ONLY` response for this RPC, SDL should transfer result code from HMI response.