### PR TITLE
Fix occupied resource releasing if app already unregistered

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2768,6 +2768,10 @@ void ApplicationManagerImpl::UnregisterApplication(
     MessageHelper::SendStopAudioPathThru(*this);
   }
 
+#ifdef SDL_REMOTE_CONTROL
+  plugin_manager_.OnUnregisterApplication(app_id);
+#endif
+
   MessageHelper::SendOnAppUnregNotificationToHMI(
       app_to_remove, is_unexpected_disconnect, *this);
   request_ctrl_.terminateAppRequests(app_id);

--- a/src/components/functional_module/include/functional_module/generic_module.h
+++ b/src/components/functional_module/include/functional_module/generic_module.h
@@ -144,6 +144,12 @@ class GenericModule {
   virtual void OnDeviceRemoved(
       const connection_handler::DeviceHandle& device) = 0;
 
+  /**
+   * @brief OnUnregisterApplication handles application unregistering event
+   * @param app_id application id which was unregistered
+   */
+  virtual void OnUnregisterApplication(const uint32_t app_id) = 0;
+
  protected:
   explicit GenericModule(ModuleID module_id);
   void NotifyObservers(ModuleObserver::Errors error);

--- a/src/components/functional_module/include/functional_module/plugin_manager.h
+++ b/src/components/functional_module/include/functional_module/plugin_manager.h
@@ -104,6 +104,13 @@ class PluginManager : public ModuleObserver {
    * @param device removed
    */
   void OnDeviceRemoved(const connection_handler::DeviceHandle& device);
+
+  /**
+   * @brief OnUnregisterApplication handles application unregistering event
+   * @param app_id application id which was unregistered
+   */
+  void OnUnregisterApplication(const uint32_t app_id);
+
   Modules& plugins();
 
  private:

--- a/src/components/functional_module/src/plugin_manager.cc
+++ b/src/components/functional_module/src/plugin_manager.cc
@@ -380,6 +380,24 @@ void PluginManager::OnDeviceRemoved(
   std::for_each(plugins_.begin(), plugins_.end(), HandleDeviceRemoved(device));
 }
 
+struct HandleApplicationUnregistered {
+ private:
+  const uint32_t app_id_;
+
+ public:
+  explicit HandleApplicationUnregistered(const uint32_t app_id)
+      : app_id_(app_id) {}
+  void operator()(PluginsValueType& x) {
+    x.second->OnUnregisterApplication(app_id_);
+  }
+};
+
+void PluginManager::OnUnregisterApplication(const uint32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  std::for_each(
+      plugins_.begin(), plugins_.end(), HandleApplicationUnregistered(app_id));
+}
+
 PluginManager::Modules& PluginManager::plugins() {
   return plugins_;
 }

--- a/src/components/functional_module/test/include/driver_generic_module_test.h
+++ b/src/components/functional_module/test/include/driver_generic_module_test.h
@@ -68,6 +68,8 @@ class DriverGenericModuleTest : public GenericModule {
   }
 
   void OnDeviceRemoved(const connection_handler::DeviceHandle&) {}
+
+  void OnUnregisterApplication(const uint32_t app_id) {}
 };
 
 }  // namespace functional_modules

--- a/src/components/functional_module/test/plugins/mock_generic_module.h
+++ b/src/components/functional_module/test/plugins/mock_generic_module.h
@@ -62,6 +62,7 @@ class MockGenericModule : public GenericModule {
                     mobile_apis::HMILevel::eType old_level));
   MOCK_METHOD1(OnDeviceRemoved,
                void(const connection_handler::DeviceHandle& device));
+  MOCK_METHOD1(OnUnregisterApplication, void(const uint32_t app_id));
   MOCK_METHOD2(CanAppChangeHMILevel,
                bool(application_manager::ApplicationSharedPtr app,
                     mobile_apis::HMILevel::eType new_level));

--- a/src/components/remote_control/include/remote_control/remote_control_plugin.h
+++ b/src/components/remote_control/include/remote_control/remote_control_plugin.h
@@ -106,6 +106,12 @@ class RemoteControlPlugin : public RemotePluginInterface {
    */
   void OnDeviceRemoved(const connection_handler::DeviceHandle& device) OVERRIDE;
 
+  /**
+   * @brief OnUnregisterApplication handles application unregistering event
+   * @param app_id application id which was unregistered
+   */
+  void OnUnregisterApplication(const uint32_t app_id) OVERRIDE;
+
   void SendHmiStatusNotification(
       application_manager::ApplicationSharedPtr app) OVERRIDE;
 

--- a/src/components/remote_control/include/remote_control/resource_allocation_manager.h
+++ b/src/components/remote_control/include/remote_control/resource_allocation_manager.h
@@ -66,6 +66,12 @@ class ResourceAllocationManager {
   virtual bool IsResourceFree(const std::string& module_type) const = 0;
 
   /**
+   * @brief OnUnregisterApplication handles application unregistering event
+   * @param app_id application id which was unregistered
+   */
+  virtual void OnUnregisterApplication(const uint32_t app_id) = 0;
+
+  /**
    * @brief AcquireResource forces acquiring resource by application
    * @param module_type resource to acquire
    * @param app_id application that acquire resource
@@ -98,7 +104,7 @@ class ResourceAllocationManager {
   virtual void SetAccessMode(
       const hmi_apis::Common_RCAccessMode::eType access_mode) = 0;
 
-  virtual ~ResourceAllocationManager() = 0;
+  virtual ~ResourceAllocationManager() {}
 };
 
 }  // namespace remote_control

--- a/src/components/remote_control/include/remote_control/resource_allocation_manager_impl.h
+++ b/src/components/remote_control/include/remote_control/resource_allocation_manager_impl.h
@@ -12,6 +12,8 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
  public:
   ResourceAllocationManagerImpl(RemotePluginInterface& rc_plugin);
 
+  ~ResourceAllocationManagerImpl();
+
   AcquireResult::eType AcquireResource(const std::string& module_type,
                                        const uint32_t app_id) OVERRIDE FINAL;
 
@@ -27,7 +29,6 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
 
   void SetAccessMode(
       const hmi_apis::Common_RCAccessMode::eType access_mode) FINAL;
-  ~ResourceAllocationManagerImpl();
 
   void ForceAcquireResource(const std::string& module_type,
                             const uint32_t app_id) OVERRIDE FINAL;
@@ -35,7 +36,17 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
   void OnDriverDisallowed(const std::string& module_type,
                           const uint32_t app_id) OVERRIDE FINAL;
 
+  void OnUnregisterApplication(const uint32_t app_id) FINAL;
+
  private:
+  /**
+   * @brief IsModuleTypeRejected check if current resource was rejected by
+   * driver for current application
+   * @param module_type resource to check
+   * @param app_id application id
+   * @return true if current resource was rejected by driver for current
+   * application, otherwise - false
+   */
   bool IsModuleTypeRejected(const std::string& module_type,
                             const uint32_t app_id);
 

--- a/src/components/remote_control/src/remote_control_plugin.cc
+++ b/src/components/remote_control/src/remote_control_plugin.cc
@@ -352,6 +352,12 @@ void RemoteControlPlugin::OnDeviceRemoved(
     service()->ResetPrimaryDevice();
   }
 }
+
+void RemoteControlPlugin::OnUnregisterApplication(const uint32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  resource_allocation_manager_.OnUnregisterApplication(app_id);
+}
+
 RCEventDispatcher& RemoteControlPlugin::event_dispatcher() {
   return event_dispatcher_;
 }

--- a/src/components/remote_control/test/include/mock_remote_control_plugin.h
+++ b/src/components/remote_control/test/include/mock_remote_control_plugin.h
@@ -37,6 +37,7 @@ class MockRemotePluginInterface : public remote_control::RemotePluginInterface {
                     mobile_apis::HMILevel::eType new_level));
   MOCK_METHOD1(OnDeviceRemoved,
                void(const connection_handler::DeviceHandle& device));
+  MOCK_METHOD1(OnUnregisterApplication, void(const uint32_t app_id));
   MOCK_METHOD1(SendHmiStatusNotification,
                void(application_manager::ApplicationSharedPtr app));
   MOCK_METHOD0(event_dispatcher, RCPluginEventDispatcher&());

--- a/src/components/remote_control/test/include/mock_resource_allocation_manager.h
+++ b/src/components/remote_control/test/include/mock_resource_allocation_manager.h
@@ -36,6 +36,7 @@ class MockResourceAllocationManager
                void(const std::string& module_type,
                     const uint32_t app_id,
                     const remote_control::ResourceState::eType state));
+  MOCK_METHOD1(OnUnregisterApplication, void(const uint32_t app_id));
   MOCK_CONST_METHOD1(IsResourceFree, bool(const std::string& module_type));
 };
 


### PR DESCRIPTION
Fixed occupied resource releasing in case its owning app currently not present in `ApplicationManager`. The problem was that if some rc application acquires some of resources using `Set/ButtonPress` and then disconnects - the second rc app could not be able to acquire same resource at all.

Following changes were done:
- Added missing description for some functions
- Updated virtual destructors definition in `ResourceAllocationManager` class hierarhy
- Added `OnUnregisterApplication()` function to `PluginManager` to notify its plugins about app unregistration
- Added `OnUnregisterApplication()` function to `ResourceAllocationManager` to automatically release
allocated resources for application which is unregistered
- Fixed UT, mock, added new UT for verifying defect