### PR TITLE
Fix rejected response after setting access mode

### DIFF
--- a/src/components/remote_control/src/resource_allocation_manager_impl.cc
+++ b/src/components/remote_control/src/resource_allocation_manager_impl.cc
@@ -132,6 +132,9 @@ bool ResourceAllocationManagerImpl::IsResourceFree(
 
 void ResourceAllocationManagerImpl::SetAccessMode(
     const hmi_apis::Common_RCAccessMode::eType access_mode) {
+  if (hmi_apis::Common_RCAccessMode::ASK_DRIVER != access_mode) {
+    rejected_resources_for_application_.clear();
+  }
   current_access_mode_ = access_mode;
 }
 


### PR DESCRIPTION
The problem was that SDL still keeping list of rejected applications for every resource even after changing of
access mode. This list is checked every time when application tries to acquire resource.
This fix solves this problem by clearing rejected applications list.