### PR TITLE
Created unit tests for class ResourceAllocationManagerImpl

### DIFF
--- a/src/components/remote_control/include/remote_control/resource_allocation_manager_impl.h
+++ b/src/components/remote_control/include/remote_control/resource_allocation_manager_impl.h
@@ -74,6 +74,28 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
   hmi_apis::Common_RCAccessMode::eType current_access_mode_;
   AskDriverCallBackPtr active_call_back_;
   RemotePluginInterface& rc_plugin_;
+
+#ifdef BUILD_TESTS
+  FRIEND_TEST(RAManagerTest,
+              ForceAcquireResource_ExpectModuleIsAllocatedToAppId);
+  FRIEND_TEST(
+      RAManagerTest,
+      OnDriverDisallowed_ModuleIsAbsentInRejectedList_ModuleIsAddedToList);
+  FRIEND_TEST(
+      RAManagerTest,
+      OnDriverDisallowed_ModuleIsExistsInRejectedList_ModuleIsNotAddedToListAgain);
+  FRIEND_TEST(RAManagerTest,
+              OnUnregisterApplication_AppWithAllocatedRes_ResourceIsReleased);
+  FRIEND_TEST(
+      RAManagerTest,
+      OnUnregisterApplication_AppWithoutAllocatedRes_OtherResourceIsNotReleased);
+  FRIEND_TEST(
+      RAManagerTest,
+      OnUnregisterApplication_AppWithRejectedRes_ModuleIsNotExistsInList);
+  FRIEND_TEST(
+      RAManagerTest,
+      OnUnregisterApplication_AppWithoutRejectedRes_ModuleIsNotExistsInList);
+#endif  // BUILD_TESTS
 };
 }  // remote_control
 


### PR DESCRIPTION
Created unit tests for ResourceAllocationManagerImpl class:
 - Created 1 unit test for void ForceAcquireResource() public method
 - Created 2 unit tests for void OnDriverDisallowed() public method
 - Created 4 unit tests for void OnUnregisterApplication public method

All created tests require access to private members of ResourceAllocationManagerImpl class. 
That's why #ifdef BUILD_TESTS section was added to ResourceAllocationManagerImpl class.