### PR TITLE
Check capabilities in Set InteriorVehicleData request

### DIFF
--- a/src/components/remote_control/include/remote_control/rc_module_constants.h
+++ b/src/components/remote_control/include/remote_control/rc_module_constants.h
@@ -41,6 +41,9 @@ const char kclimateControlCapabilities[] = "climateControlCapabilities";
 const char kradioControlCapabilities[] = "radioControlCapabilities";
 const char kbuttonCapabilities[] = "buttonCapabilities";
 // RemoteControlCapabilities constants
+
+const char kRadioControlData[] = "radioControlData";
+const char kClimateControlData[] = "climateControlData";
 }  //  strings
 
 namespace result_codes {


### PR DESCRIPTION
Module data in Set interior vehicle data should be checked by capabilities.
In case if Some module data is not available by capabilities, SDL should respond with unsupported resource to mobile 

For example 
Capabilities : 
```
"radioControlCapabilities": [{
                    "moduleName": "radio",
                    "radioEnableAvailable": false,

```

Request: 
```
"moduleData" : {
   "radioControlData" :{
     "radioEnable" : "true"
  }
}
```

SDL should check that radioEnable is not available by capabilities and return error on Mobile 