### PR TITLE
Reset resource allocation if rc functionality disabled

### DIFF
--- a/src/components/remote_control/include/remote_control/resource_allocation_manager.h
+++ b/src/components/remote_control/include/remote_control/resource_allocation_manager.h
@@ -104,6 +104,11 @@ class ResourceAllocationManager {
   virtual void SetAccessMode(
       const hmi_apis::Common_RCAccessMode::eType access_mode) = 0;
 
+  /**
+   * @brief Remove all information about all allocations
+   */
+  virtual void ResetAllAllocations() = 0;
+
   virtual ~ResourceAllocationManager() {}
 };
 

--- a/src/components/remote_control/include/remote_control/resource_allocation_manager_impl.h
+++ b/src/components/remote_control/include/remote_control/resource_allocation_manager_impl.h
@@ -38,6 +38,8 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
 
   void OnUnregisterApplication(const uint32_t app_id) FINAL;
 
+  void ResetAllAllocations() FINAL;
+
  private:
   /**
    * @brief IsModuleTypeRejected check if current resource was rejected by

--- a/src/components/remote_control/src/commands/on_remote_control_settings_notification.cc
+++ b/src/components/remote_control/src/commands/on_remote_control_settings_notification.cc
@@ -89,6 +89,8 @@ void OnRemoteControlSettingsNotification::Execute() {
     LOG4CXX_DEBUG(logger_, "RC Functionality remains unchanged");
     return;
   }
+  ResourceAllocationManager& allocation_manager =
+      rc_module_.resource_allocation_manager();
   const bool is_allowed = value[message_params::kAllowed].asBool();
   if (is_allowed) {
     LOG4CXX_DEBUG(logger_, "Allowing RC Functionality");
@@ -98,13 +100,12 @@ void OnRemoteControlSettingsNotification::Execute() {
 
     const hmi_apis::Common_RCAccessMode::eType access_mode_ =
         MessageHelper::AccessModeFromString(access_mode);
-    ResourceAllocationManager& allocation_manager =
-        rc_module_.resource_allocation_manager();
     LOG4CXX_DEBUG(logger_, "Setting up access mode : " << access_mode);
     allocation_manager.SetAccessMode(access_mode_);
   } else {
     LOG4CXX_DEBUG(logger_, "Disallowing RC Functionality");
     DisallowRCFunctionality();
+    allocation_manager.ResetAllAllocations();
   }
 }
 

--- a/src/components/remote_control/src/commands/set_interior_vehicle_data_request.cc
+++ b/src/components/remote_control/src/commands/set_interior_vehicle_data_request.cc
@@ -154,8 +154,10 @@ void SetInteriorVehicleDataRequest::Execute() {
   }
 
   if (module_type_and_data_match) {
-    if (!CheckIfModuleDataExistInCapabilities(*(service()->GetRCCapabilities()),
-                                              module_data)) {
+    const smart_objects::SmartObject* capabilities =
+        service()->GetRCCapabilities();
+    if (capabilities &&
+        !CheckIfModuleDataExistInCapabilities(*capabilities, module_data)) {
       LOG4CXX_WARN(logger_, "Accessing not supported module data");
       SendResponse(false,
                    result_codes::kUnsupportedResource,

--- a/src/components/remote_control/src/resource_allocation_manager_impl.cc
+++ b/src/components/remote_control/src/resource_allocation_manager_impl.cc
@@ -226,4 +226,11 @@ void ResourceAllocationManagerImpl::OnUnregisterApplication(
   }
 }
 
+void ResourceAllocationManagerImpl::ResetAllAllocations() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  allocated_resources_.clear();
+  rejected_resources_for_application_.clear();
+  resources_state_.clear();
+}
+
 }  // namespace remote_control

--- a/src/components/remote_control/test/include/mock_resource_allocation_manager.h
+++ b/src/components/remote_control/test/include/mock_resource_allocation_manager.h
@@ -38,6 +38,7 @@ class MockResourceAllocationManager
                     const remote_control::ResourceState::eType state));
   MOCK_METHOD1(OnUnregisterApplication, void(const uint32_t app_id));
   MOCK_CONST_METHOD1(IsResourceFree, bool(const std::string& module_type));
+  MOCK_METHOD0(ResetAllAllocations, void());
 };
 
 }  // namespace remote_control_test


### PR DESCRIPTION
After disabling RC functionality all resources should be free.
After next enabling RC functionality new application should be able to grab resources that we allocated for other applications before disabling RC 