### PR TITLE
Fixes wrong AppHMIType conversion for RC applications

### DIFF
--- a/src/appMain/sdl_preloaded_pt.json
+++ b/src/appMain/sdl_preloaded_pt.json
@@ -2364,7 +2364,11 @@
                 "groups_primaryRC": [
                     "Base-4",
                     "RemoteControl"
-                ]
+                ],
+		"moduleType": [
+			"RADIO",
+			"CLIMATE"
+		]
             },
             "device": {
                 "keep_context": false,

--- a/src/components/policy/policy_regular/include/policy/policy_table/enums.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/enums.h
@@ -104,8 +104,8 @@ enum AppHMIType {
   AHT_BACKGROUND_PROCESS,
   AHT_TESTING,
   AHT_SYSTEM,
-  AHT_REMOTE_CONTROL,
-  AHT_PROJECTION
+  AHT_PROJECTION,
+  AHT_REMOTE_CONTROL
 };
 bool IsValidEnum(AppHMIType val);
 const char* EnumToJsonString(AppHMIType val);


### PR DESCRIPTION
Due to AppHMIType order incorrect conversion was happening which caused policy permissions issues.
Also fixed preloaded json by adding proper modules for default applications.