### PR TITLE
Fixes validation of SetInteriorVehicleData parameters with HMI capabilities

### DIFF
--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -306,6 +306,7 @@
                     "moduleName": "primary_climate",
                     "fanSpeedAvailable": true,
                     "desiredTemperatureAvailable": true,
+                    "currentTemperatureAvailable": true,
                     "acEnableAvailable": true,
                     "acMaxEnableAvailable": true,
                     "circulateAirEnableAvailable": true,


### PR DESCRIPTION
There were several issues:
- assert due to unexpected structure of HMI capabilities
- missing validation parameter for incoming request
- wrong logic of checking of 'climate' and 'radio' modules when come both
- missing parameter in capabilities json file