### PR TITLE
Fix UNSUPPORTED_RESOURCE response in case HMI RC interface is not available

### DIFF
--- a/src/components/application_manager/include/application_manager/core_service.h
+++ b/src/components/application_manager/include/application_manager/core_service.h
@@ -157,6 +157,14 @@ class CoreService : public Service {
   bool IsRemoteControlApplication(ApplicationSharedPtr app) const FINAL;
 
   /**
+   * @brief Gets current state of the specified interface
+   * @param interface which state to get
+   * @return true if specified interface available otherwise false
+   */
+  bool IsInterfaceAvailable(
+      const HmiInterfaces::InterfaceID interface) const FINAL;
+
+  /**
    * Removes fake parameters from request to HMI
    * @param message message to handle
    */

--- a/src/components/application_manager/include/application_manager/service.h
+++ b/src/components/application_manager/include/application_manager/service.h
@@ -38,6 +38,7 @@
 #include <vector>
 #include "application_manager/application.h"
 #include "application_manager/message.h"
+#include "application_manager/hmi_interfaces.h"
 
 namespace application_manager {
 
@@ -218,6 +219,14 @@ class Service {
    * @return true if application has remote control functions
    */
   virtual bool IsRemoteControlApplication(ApplicationSharedPtr app) const = 0;
+
+  /**
+   * @brief Gets current state of the specified interface
+   * @param interface which state to get
+   * @return true if specified interface available otherwise false
+   */
+  virtual bool IsInterfaceAvailable(
+      const HmiInterfaces::InterfaceID interface) const = 0;
 
   /**
    * Gets all allowed module types

--- a/src/components/application_manager/src/core_service.cc
+++ b/src/components/application_manager/src/core_service.cc
@@ -193,6 +193,17 @@ bool CoreService::IsRemoteControlApplication(ApplicationSharedPtr app) const {
   return false;
 }
 
+bool CoreService::IsInterfaceAvailable(
+    const HmiInterfaces::InterfaceID interface) const {
+#ifdef SDL_REMOTE_CONTROL
+  HmiInterfaces& hmi_interfaces = application_manager_.hmi_interfaces();
+  const HmiInterfaces::InterfaceState state =
+      hmi_interfaces.GetInterfaceState(interface);
+  return HmiInterfaces::STATE_NOT_AVAILABLE != state;
+#endif  // SDL_REMOTE_CONTROL
+  return false;
+}
+
 void CoreService::RemoveHMIFakeParameters(
     application_manager::MessagePtr& message) {
   application_manager_.RemoveHMIFakeParameters(message);

--- a/src/components/functional_module/test/include/mock_service.h
+++ b/src/components/functional_module/test/include/mock_service.h
@@ -80,6 +80,8 @@ class MockService : public Service {
 
   MOCK_CONST_METHOD1(IsRemoteControlApplication,
                      bool(ApplicationSharedPtr app));
+  MOCK_CONST_METHOD1(IsInterfaceAvailable,
+                     bool(const HmiInterfaces::InterfaceID interface));
   MOCK_CONST_METHOD2(GetModuleTypes,
                      bool(const std::string& application_id,
                           std::vector<std::string>* modules));

--- a/src/components/remote_control/src/commands/base_command_request.cc
+++ b/src/components/remote_control/src/commands/base_command_request.cc
@@ -106,6 +106,19 @@ void BaseCommandRequest::SendResponse(const bool success,
 void BaseCommandRequest::SendMessageToHMI(
     const application_manager::MessagePtr& message_to_send) {
   LOG4CXX_AUTO_TRACE(logger_);
+  using application_manager::HmiInterfaces;
+
+  const bool is_rc_available =
+      service_->IsInterfaceAvailable(HmiInterfaces::HMI_INTERFACE_RC);
+  LOG4CXX_DEBUG(logger_, "HMI interface RC is available: " << is_rc_available);
+  if (!is_rc_available) {
+    const bool success = false;
+    const char* result_code = result_codes::kUnsupportedResource;
+    const std::string info = "Remote control is not supported by system";
+
+    SendResponse(success, result_code, info);
+    return;
+  }
 
   const std::string function_name = message_to_send->function_name();
   const int32_t correlation_id = message_to_send->correlation_id();

--- a/src/components/remote_control/test/commands/button_press_request_test.cc
+++ b/src/components/remote_control/test/commands/button_press_request_test.cc
@@ -143,6 +143,8 @@ class ButtonPressRequestTest : public ::testing::Test {
     rc_capabilities_[strings::kbuttonCapabilities] = button_caps;
     ON_CALL(*mock_service_, GetRCCapabilities())
         .WillByDefault(Return(&rc_capabilities_));
+    ON_CALL(*mock_service_, IsInterfaceAvailable(_))
+        .WillByDefault(Return(true));
   }
 
   remote_control::request_controller::MobileRequestPtr CreateCommand(

--- a/src/components/remote_control/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/remote_control/test/commands/get_interior_vehicle_data_request_test.cc
@@ -113,6 +113,8 @@ class GetInteriorVehicleDataRequestTest : public ::testing::Test {
     ON_CALL(mock_module_, service()).WillByDefault(Return(mock_service_));
     ON_CALL(*mock_service_, GetApplication(app_id_))
         .WillByDefault(Return(mock_app_));
+    ON_CALL(*mock_service_, IsInterfaceAvailable(_))
+        .WillByDefault(Return(true));
     EXPECT_CALL(mock_module_, event_dispatcher())
         .WillRepeatedly(ReturnRef(event_dispatcher_));
     ServicePtr exp_service(mock_service_);

--- a/src/components/remote_control/test/commands/on_remote_control_settings_test.cc
+++ b/src/components/remote_control/test/commands/on_remote_control_settings_test.cc
@@ -104,6 +104,8 @@ class OnRemoteControlSettingsNotificationTest : public ::testing::Test {
             utils::MakeShared<remote_control::RCAppExtension>(kModuleId)) {
     ON_CALL(mock_module_, resource_allocation_manager())
         .WillByDefault(ReturnRef(mock_allocation_manager_));
+    ON_CALL(*mock_service_, IsInterfaceAvailable(_))
+        .WillByDefault(Return(true));
     apps_.push_back(mock_app_);
   }
 

--- a/src/components/remote_control/test/commands/set_interior_vehicle_data_request_test.cc
+++ b/src/components/remote_control/test/commands/set_interior_vehicle_data_request_test.cc
@@ -122,6 +122,8 @@ class SetInteriorVehicleDataRequestTest : public ::testing::Test {
         .WillByDefault(ReturnRef(mock_allocation_manager_));
     ON_CALL(mock_module_, service()).WillByDefault(Return(mock_service_));
     ON_CALL(*mock_service_, GetApplication(_)).WillByDefault(Return(mock_app_));
+    ON_CALL(*mock_service_, IsInterfaceAvailable(_))
+        .WillByDefault(Return(true));
     ON_CALL(mock_module_, event_dispatcher())
         .WillByDefault(ReturnRef(event_dispatcher_));
     ServicePtr exp_service(mock_service_);


### PR DESCRIPTION
There was no checks that RC interface is not ready on HMI side so SDL sends RC RPCs all time.
Following changes were done:
- Added `IsInterfaceAvailable()` function to core service to check HMI interfaces availability
- Added check of RC interface availability in base command request
- Fixed unit tests due to changes in implementation