### PR TITLE
Change param name to module name in radio and clime capabilities

### DIFF
--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1380,7 +1380,7 @@
 
  <struct name="RadioControlCapabilities">
    <description>Contains information about a radio control module's capabilities.</description>
-   <param name="name" type="String" maxlength="50" mandatory="true" >
+   <param name="moduleName" type="String" maxlength="50" mandatory="true" >
      <description>The short name or a short description of the radio control module.</description>
    </param>
    <param name="radioEnableAvailable" type="Boolean" mandatory="false">
@@ -1492,7 +1492,7 @@
 
    <struct name="ClimateControlCapabilities">
    <description>Contains information about a climate control module's capabilities.</description>
-   <param name="name" type="String" maxlength="50" mandatory="true" >
+   <param name="moduleName" type="String" maxlength="50" mandatory="true" >
      <description>The short name or a short description of the climate control module.</description>
    </param>
    <param name="fanSpeedAvailable" type="Boolean" mandatory="false">

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -1411,7 +1411,7 @@
 
   <struct name="RadioControlCapabilities">
     <description>Contains information about a radio control module's capabilities.</description>
-    <param name="name" type="String" maxlength="50" mandatory="true" >
+    <param name="moduleName" type="String" maxlength="50" mandatory="true" >
       <description>The short name or a short description of the radio control module.</description>
     </param>
     <param name="radioEnableAvailable" type="Boolean" mandatory="false">
@@ -1523,7 +1523,7 @@
 
 <struct name="ClimateControlCapabilities">
   <description>Contains information about a climate control module's capabilities.</description>
-  <param name="name" type="String" maxlength="50" mandatory="true" >
+  <param name="moduleName" type="String" maxlength="50" mandatory="true" >
     <description>The short name or a short description of the climate control module.</description>
   </param>
   <param name="fanSpeedAvailable" type="Boolean" mandatory="false">

--- a/src/components/remote_control/src/commands/set_interior_vehicle_data_request.cc
+++ b/src/components/remote_control/src/commands/set_interior_vehicle_data_request.cc
@@ -116,8 +116,18 @@ bool CheckControlDataByCapabilities(
                   "Checking request parameter "
                       << request_parameter
                       << " with capabilities. Appropriate key is " << caps_key);
-    DCHECK_OR_RETURN(capabilities_status.keyExists(caps_key), false);
+    if (!capabilities_status.keyExists(caps_key)) {
+      LOG4CXX_DEBUG(logger_,
+                    "Capability "
+                        << caps_key
+                        << " is missed in RemoteControl capabilities");
+      return false;
+    }
     if (!capabilities_status[caps_key].asBool()) {
+      LOG4CXX_DEBUG(logger_,
+                    "Capability "
+                        << caps_key
+                        << " is switched off in RemoteControl capabilities");
       return false;
     }
   }


### PR DESCRIPTION
In RadioControlCapabilities struct and ClimateControlCapabilities param was incorrect name of parameter. Correct name - "moduleName"

Also added additional logs to observe cause of rejected capabilities