### PR TITLE
Add missed addCurrentTemperature parameter in climate capabilities

### DIFF
--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1495,6 +1495,12 @@
    <param name="moduleName" type="String" maxlength="50" mandatory="true" >
      <description>The short name or a short description of the climate control module.</description>
    </param>
+   <param name="currentTemperatureAvailable" type="Boolean" mandatory="false">
+     <description>
+       Availability of the reading of current temperature.
+       True: Available, False: Not Available, Not present: Not Available.
+     </description>
+   </param>
    <param name="fanSpeedAvailable" type="Boolean" mandatory="false">
      <description>
        Availability of the control of fan speed.

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -1526,6 +1526,12 @@
   <param name="moduleName" type="String" maxlength="50" mandatory="true" >
     <description>The short name or a short description of the climate control module.</description>
   </param>
+  <param name="currentTemperatureAvailable" type="Boolean" mandatory="false">
+    <description>
+      Availability of the reading of current temperature.
+      True: Available, False: Not Available, Not present: Not Available.
+    </description>
+  </param>
   <param name="fanSpeedAvailable" type="Boolean" mandatory="false">
     <description>
       Availability of the control of fan speed.


### PR DESCRIPTION
Was missed parameter current temperature_available in capabilities.

This PR add current temperatire parameter to mobile and HMI api's 