### PR TITLE
Return unsupported resource instead of invalid data

### DIFF
--- a/src/components/remote_control/src/commands/button_press_request.cc
+++ b/src/components/remote_control/src/commands/button_press_request.cc
@@ -204,7 +204,7 @@ void ButtonPressRequest::Execute() {
   } else {
     LOG4CXX_WARN(logger_, "Requested button is not exists in capabilities!");
     SendResponse(false,
-                 result_codes::kInvalidData,
+                 result_codes::kUnsupportedResource,
                  "Requested button is not exists in capabilities!");
   }
 }


### PR DESCRIPTION
If button do not exist in capabilities SDL should respond unsupported resource to mobile