### PR TITLE
Remove redundant OnHMIStatus notification

### DIFF
--- a/src/components/application_manager/src/core_service.cc
+++ b/src/components/application_manager/src/core_service.cc
@@ -251,7 +251,6 @@ void CoreService::SubscribeToHMINotification(
 void CoreService::ChangeNotifyHMILevel(ApplicationSharedPtr app,
                                        mobile_apis::HMILevel::eType level) {
   application_manager_.ChangeAppsHMILevel(app->app_id(), level);
-  MessageHelper::SendHMIStatusNotification(*app, application_manager_);
 }
 
 const smart_objects::SmartObject* CoreService::GetRCCapabilities() const {


### PR DESCRIPTION
In case when we send: HMI->SDL: RC.OnRemoteControlSettings(allowed:false),
SDL sends OnHMIStatus(NONE) twice for each application, but should send it only once for each app,
so I removed it redundant notification