### PR TITLE
Fixes processing of OnRemoteControlSettings w/o access mode specified

### DIFF
--- a/src/components/remote_control/include/remote_control/message_helper.h
+++ b/src/components/remote_control/include/remote_control/message_helper.h
@@ -114,6 +114,14 @@ class MessageHelper {
   static hmi_apis::Common_RCAccessMode::eType AccessModeFromString(
       const std::string& access_mode);
 
+  /**
+   * @brief AccessModeToString converts enum values to string
+   * @param access_mode Access mode enum value
+   * @return Appropriate string value
+   */
+  static std::string AccessModeToString(
+      const hmi_apis::Common_RCAccessMode::eType access_mode);
+
  private:
   MessageHelper();
 

--- a/src/components/remote_control/include/remote_control/resource_allocation_manager.h
+++ b/src/components/remote_control/include/remote_control/resource_allocation_manager.h
@@ -82,6 +82,12 @@ class ResourceAllocationManager {
       const hmi_apis::Common_RCAccessMode::eType access_mode) = 0;
 
   /**
+   * @brief Get last set access mode for acquiring resource
+   * @param access_mode
+   */
+  virtual hmi_apis::Common_RCAccessMode::eType GetAccessMode() const = 0;
+
+  /**
    * @brief Remove all information about all allocations
    */
   virtual void ResetAllAllocations() = 0;

--- a/src/components/remote_control/include/remote_control/resource_allocation_manager_impl.h
+++ b/src/components/remote_control/include/remote_control/resource_allocation_manager_impl.h
@@ -26,6 +26,8 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
   void SetAccessMode(
       const hmi_apis::Common_RCAccessMode::eType access_mode) FINAL;
 
+  hmi_apis::Common_RCAccessMode::eType GetAccessMode() const FINAL;
+
   void ForceAcquireResource(const std::string& module_type,
                             const uint32_t app_id) OVERRIDE FINAL;
 

--- a/src/components/remote_control/src/commands/on_remote_control_settings_notification.cc
+++ b/src/components/remote_control/src/commands/on_remote_control_settings_notification.cc
@@ -93,15 +93,23 @@ void OnRemoteControlSettingsNotification::Execute() {
       rc_module_.resource_allocation_manager();
   const bool is_allowed = value[message_params::kAllowed].asBool();
   if (is_allowed) {
+    hmi_apis::Common_RCAccessMode::eType access_mode =
+        hmi_apis::Common_RCAccessMode::INVALID_ENUM;
     LOG4CXX_DEBUG(logger_, "Allowing RC Functionality");
-    const std::string access_mode =
-        value.get(message_params::kAccessMode, enums_value::kAutoAllow)
-            .asString();
+    if (value.isMember(message_params::kAccessMode)) {
+      const std::string access_mode_str =
+          value.get(message_params::kAccessMode, enums_value::kAutoAllow)
+              .asString();
 
-    const hmi_apis::Common_RCAccessMode::eType access_mode_ =
-        MessageHelper::AccessModeFromString(access_mode);
-    LOG4CXX_DEBUG(logger_, "Setting up access mode : " << access_mode);
-    allocation_manager.SetAccessMode(access_mode_);
+      access_mode = MessageHelper::AccessModeFromString(access_mode_str);
+      LOG4CXX_DEBUG(logger_, "Setting up access mode : " << access_mode_str);
+    } else {
+      access_mode = allocation_manager.GetAccessMode();
+      LOG4CXX_DEBUG(logger_,
+                    "No access mode received. Using last known: "
+                        << MessageHelper::AccessModeToString(access_mode));
+    }
+    allocation_manager.SetAccessMode(access_mode);
   } else {
     LOG4CXX_DEBUG(logger_, "Disallowing RC Functionality");
     DisallowRCFunctionality();

--- a/src/components/remote_control/src/resource_allocation_manager_impl.cc
+++ b/src/components/remote_control/src/resource_allocation_manager_impl.cc
@@ -144,6 +144,11 @@ void ResourceAllocationManagerImpl::SetAccessMode(
   current_access_mode_ = access_mode;
 }
 
+hmi_apis::Common_RCAccessMode::eType
+ResourceAllocationManagerImpl::GetAccessMode() const {
+  return current_access_mode_;
+}
+
 void ResourceAllocationManagerImpl::ForceAcquireResource(
     const std::string& module_type, const uint32_t app_id) {
   LOG4CXX_DEBUG(logger_, "Force " << app_id << " acquiring " << module_type);

--- a/src/components/remote_control/test/include/mock_resource_allocation_manager.h
+++ b/src/components/remote_control/test/include/mock_resource_allocation_manager.h
@@ -20,6 +20,7 @@ class MockResourceAllocationManager
                void(const std::string& module_type, const uint32_t app_id));
   MOCK_METHOD1(SetAccessMode,
                void(const hmi_apis::Common_RCAccessMode::eType access_mode));
+  MOCK_CONST_METHOD0(GetAccessMode, hmi_apis::Common_RCAccessMode::eType());
   MOCK_METHOD3(SetResourceState,
                void(const std::string& module_type,
                     const uint32_t app_id,

--- a/src/components/remote_control/test/src/resource_allocation_manager_impl_test.cc
+++ b/src/components/remote_control/test/src/resource_allocation_manager_impl_test.cc
@@ -254,4 +254,24 @@ TEST_F(RAManagerTest,
             ra_manager.AcquireResource(kModuleType1, kAppId2));
 }
 
+TEST_F(RAManagerTest, GetAccessMode_ExpectedSameAsHadSet) {
+  ResourceAllocationManagerImpl ra_manager(mock_module_);
+
+  ra_manager.SetAccessMode(hmi_apis::Common_RCAccessMode::AUTO_DENY);
+  EXPECT_EQ(hmi_apis::Common_RCAccessMode::AUTO_DENY,
+            ra_manager.GetAccessMode());
+
+  ra_manager.SetAccessMode(hmi_apis::Common_RCAccessMode::ASK_DRIVER);
+  EXPECT_EQ(hmi_apis::Common_RCAccessMode::ASK_DRIVER,
+            ra_manager.GetAccessMode());
+
+  ra_manager.SetAccessMode(hmi_apis::Common_RCAccessMode::AUTO_ALLOW);
+  EXPECT_EQ(hmi_apis::Common_RCAccessMode::AUTO_ALLOW,
+            ra_manager.GetAccessMode());
+
+  ra_manager.SetAccessMode(hmi_apis::Common_RCAccessMode::INVALID_ENUM);
+  EXPECT_EQ(hmi_apis::Common_RCAccessMode::INVALID_ENUM,
+            ra_manager.GetAccessMode());
+}
+
 }  // namespace remote_control


### PR DESCRIPTION
In case notification disabled and later on enabled RC functionality
but didn't provide access mode SDL must use last known mode.