### PR TITLE
Fix process RPCs in case when HMI RC.GetCapabilities response was without remoteControlCapability parameter

### DIFF
--- a/src/components/application_manager/src/commands/hmi/rc_get_capabilities_response.cc
+++ b/src/components/application_manager/src/commands/hmi/rc_get_capabilities_response.cc
@@ -46,10 +46,8 @@ void RCGetCapabilitiesResponse::Run() {
 
   HMICapabilities& hmi_capabilities = application_manager_.hmi_capabilities();
 
-  if ((*message_)[strings::msg_params].keyExists(strings::rc_capability)) {
-    hmi_capabilities.set_rc_capability(
-        (*message_)[strings::msg_params][strings::rc_capability]);
-  }
+  hmi_capabilities.set_rc_capability(
+      (*message_)[strings::msg_params][strings::rc_capability]);
 }
 
 }  // namespace commands


### PR DESCRIPTION
Fix process RPCs in case when HMI RC.GetCapabilities response was without remoteControlCapability parameter