### PR TITLE
Remove redundant dependency of media_manager tests from plugin_manager

### DIFF
--- a/src/components/media_manager/test/CMakeLists.txt
+++ b/src/components/media_manager/test/CMakeLists.txt
@@ -62,13 +62,6 @@ set(LIBRARIES
     ${SecurityManagerLibrary}
 )
 
-if(REMOTE_CONTROL)
-    SET (LIBRARIES
-      ${LIBRARIES}
-      FunctionalModule
-    )
-endif(REMOTE_CONTROL)
-
 if(EXTENDED_MEDIA_MODE)
   list(APPEND LIBRARIES
     ${GSTREAMER_gstreamer_LIBRARY})


### PR DESCRIPTION
media manager tests have no dependency from implementation of plugin manager.
Removed redundant linkage 