### PR TITLE
Fix DISALLOWED response for GetSystemCapability RPC request

### DIFF
--- a/src/components/remote_control/remote_sdl_pt.json
+++ b/src/components/remote_control/remote_sdl_pt.json
@@ -98,6 +98,12 @@
                         "FULL",
                         "LIMITED"]
                     },
+                    "GetSystemCapability": {
+                        "hmi_levels": ["BACKGROUND",
+                        "FULL",
+                        "LIMITED",
+                        "NONE"]
+                    },
                     "ListFiles": {
                         "hmi_levels": ["BACKGROUND",
                         "FULL",


### PR DESCRIPTION
There was a problem with `GetSystemCapability` RPC for SDL build with `REMOTE_CONTROL=ON`. This RPC was not included to remote SDL PT json file so SDL always blocks this RPC by policy.

In this commit `GetSystemCapability` RPC was added to `remote_sdl_pt.json` as it's done for default `sdl_preloaded_pt.json`