### PR TITLE
Fix RC request controller custom timeout

### DIFF
--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -271,7 +271,3 @@ MaxNumberOfiOSDevice = 10
 WaitTimeBetweenApps = 4000
 ; App Launch on iOS devices SDL feature enabler/disabler 
 EnableAppLaunchIOS = true
-
-[Remote Control]
-; Timeout to wait for HMI response for RC APIs coming from mobile
-timeout_period_seconds = 10

--- a/src/components/application_manager/include/application_manager/core_service.h
+++ b/src/components/application_manager/include/application_manager/core_service.h
@@ -166,8 +166,13 @@ class CoreService : public Service {
    * @param message Message to check
    * @return Check result
    */
-  MessageValidationResult ValidateMessageBySchema(
-      const Message& message) OVERRIDE;
+  MessageValidationResult ValidateMessageBySchema(const Message& message) FINAL;
+
+  /**
+   * @brief Gets application manager settings structure
+   * @return reference to application manager settings structure
+   */
+  const ApplicationManagerSettings& GetSettings() const FINAL;
 
  private:
   /**

--- a/src/components/application_manager/include/application_manager/service.h
+++ b/src/components/application_manager/include/application_manager/service.h
@@ -37,6 +37,7 @@
 #include <sstream>
 #include <vector>
 #include "application_manager/application.h"
+#include "application_manager/application_manager_settings.h"
 #include "application_manager/message.h"
 #include "application_manager/hmi_interfaces.h"
 
@@ -167,6 +168,12 @@ class Service {
    */
   virtual MessageValidationResult ValidateMessageBySchema(
       const Message& message) = 0;
+
+  /**
+   * @brief Gets application manager settings structure
+   * @return reference to application manager settings structure
+   */
+  virtual const ApplicationManagerSettings& GetSettings() const = 0;
 };
 
 typedef utils::SharedPtr<Service> ServicePtr;

--- a/src/components/application_manager/src/core_service.cc
+++ b/src/components/application_manager/src/core_service.cc
@@ -221,4 +221,8 @@ MessageValidationResult CoreService::ValidateMessageBySchema(
   return result;
 }
 
+const ApplicationManagerSettings& CoreService::GetSettings() const {
+  return application_manager_.get_settings();
+}
+
 }  // namespace application_manager

--- a/src/components/functional_module/test/include/mock_service.h
+++ b/src/components/functional_module/test/include/mock_service.h
@@ -68,6 +68,7 @@ class MockService : public Service {
   MOCK_METHOD1(ValidateMessageBySchema,
                application_manager::MessageValidationResult(
                    const application_manager::Message& message));
+  MOCK_CONST_METHOD0(GetSettings, const ApplicationManagerSettings&());
 };
 }
 // namespace application_manager

--- a/src/components/remote_control/include/remote_control/remote_control_plugin.h
+++ b/src/components/remote_control/include/remote_control/remote_control_plugin.h
@@ -97,12 +97,30 @@ class RemoteControlPlugin : public RemotePluginInterface {
    */
   void OnUnregisterApplication(const uint32_t app_id) OVERRIDE;
 
+  /**
+   * @brief Sends HMI status notification to mobile
+   * @param app application with changed HMI status
+   **/
   void SendHmiStatusNotification(
       application_manager::ApplicationSharedPtr app) OVERRIDE;
 
+  /**
+   * @brief Getter for event_dispatcher
+   * @return reference to RCEventDispatcher instance
+   */
   RCEventDispatcher& event_dispatcher() OVERRIDE;
 
+  /**
+   * @brief Getter for resource_allocation_manager
+   * @return reference to ResourceAllocationManager instance
+   */
   ResourceAllocationManager& resource_allocation_manager() OVERRIDE;
+
+  /**
+   * @brief Overriden setter for service
+   * @param service pointer to new service instance
+   */
+  void set_service(application_manager::ServicePtr service) OVERRIDE;
 
  protected:
   /**
@@ -111,11 +129,16 @@ class RemoteControlPlugin : public RemotePluginInterface {
   virtual void RemoveAppExtensions() OVERRIDE;
 
  private:
-  void SubscribeOnFunctions();
-  void NotifyMobiles(application_manager::MessagePtr msg);
+  /**
+   * @brief Trigger actions which should be done after plugin service instance
+   * have been changed
+   */
+  void OnPluginServiceChanged();
 
-  functional_modules::ProcessResult HandleMessage(
-      application_manager::MessagePtr msg);
+  /**
+   * @brief Subscribes on all RC related functions
+   */
+  void SubscribeOnFunctions();
 
   functional_modules::PluginInfo plugin_info_;
   bool is_scan_started_;

--- a/src/components/remote_control/include/remote_control/request_controller.h
+++ b/src/components/remote_control/include/remote_control/request_controller.h
@@ -83,7 +83,17 @@ class RequestController
    */
   void DeleteRequest(const uint32_t& mobile_correlation_id);
 
-  void OnTimeoutTriggered(const TrackableMessage& expired);
+  /**
+   * @brief Sets timeout value for RC requests
+   * @param timeout_seconds new timeout value in seconds
+   */
+  void SetRequestTimeout(const functional_modules::TimeUnit timeout_seconds);
+
+  /**
+   * @brief Triggers actions when timeout for some request is expired
+   * @param expired reference to request which timeout was expired
+   */
+  void OnTimeoutTriggered(const TrackableMessage& expired) OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(RequestController);

--- a/src/components/remote_control/src/remote_control_plugin.cc
+++ b/src/components/remote_control/src/remote_control_plugin.cc
@@ -233,16 +233,6 @@ void RemoteControlPlugin::SendHmiStatusNotification(
   service()->SendMessageToMobile(msg);
 }
 
-void RemoteControlPlugin::NotifyMobiles(
-    application_manager::MessagePtr message) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  request_controller::MobileRequestPtr command =
-      RCCommandFactory::CreateCommand(message, *this);
-  if (command) {
-    command->Run();
-  }
-}
-
 void RemoteControlPlugin::SendResponseToMobile(
     application_manager::MessagePtr msg) {
   LOG4CXX_DEBUG(logger_, "Response to mobile: " << msg->json_message());
@@ -313,6 +303,18 @@ void RemoteControlPlugin::OnAppHMILevelChanged(
 void RemoteControlPlugin::OnUnregisterApplication(const uint32_t app_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   resource_allocation_manager_.OnUnregisterApplication(app_id);
+}
+
+void RemoteControlPlugin::OnPluginServiceChanged() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const functional_modules::TimeUnit timeout_msec =
+      service()->GetSettings().default_timeout();
+  request_controller_.SetRequestTimeout(timeout_msec / 1000);
+}
+
+void RemoteControlPlugin::set_service(application_manager::ServicePtr service) {
+  RemotePluginInterface::set_service(service);
+  OnPluginServiceChanged();
 }
 
 RCEventDispatcher& RemoteControlPlugin::event_dispatcher() {

--- a/src/components/remote_control/src/request_controller.cc
+++ b/src/components/remote_control/src/request_controller.cc
@@ -33,7 +33,6 @@
 #include "remote_control/request_controller.h"
 #include "json/json.h"
 #include "utils/logger.h"
-#include "functional_module/settings.h"
 
 namespace remote_control {
 namespace request_controller {
@@ -41,12 +40,6 @@ namespace request_controller {
 CREATE_LOGGERPTR_GLOBAL(logger_, "RCRequestController")
 
 RequestController::RequestController() {
-  functional_modules::TimeUnit timeout_seconds = 100;
-  functional_modules::Settings settings;
-  settings.ReadParameter(
-      "Remote Control", "timeout_period_seconds", &timeout_seconds);
-  timer_.set_period(timeout_seconds);
-  LOG4CXX_DEBUG(logger_, "Timeout is set to " << timeout_seconds);
   timer_.AddObserver(this);
   time_director_.RegisterTimer(timer_);
 }
@@ -91,6 +84,12 @@ void RequestController::OnTimeoutTriggered(const TrackableMessage& expired) {
   }
   it->second->OnTimeout();
   mobile_request_list_.erase(it);
+}
+
+void RequestController::SetRequestTimeout(
+    const functional_modules::TimeUnit timeout_seconds) {
+  LOG4CXX_DEBUG(logger_, "RC request timeout is set to " << timeout_seconds);
+  timer_.set_period(timeout_seconds);
 }
 
 }  //  namespace request_controller

--- a/src/components/remote_control/test/CMakeLists.txt
+++ b/src/components/remote_control/test/CMakeLists.txt
@@ -40,10 +40,8 @@ endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCOV_FLAGS}")
 
-configure_file(smartDeviceLink.ini smartDeviceLink.ini COPYONLY)
-
 # use, i.e. don't skip the full RPATH for the build tree
-#SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+#SET(CMAKE_SKIP_BUILD_RPATH FALSE)
 
 # when building, don't use the install RPATH already
 # (but later on when installing)

--- a/src/components/remote_control/test/smartDeviceLink.ini
+++ b/src/components/remote_control/test/smartDeviceLink.ini
@@ -1,4 +1,0 @@
-[Remote Control]
-address = 127.0.0.1
-port = 8092
-timeout_period_seconds = 10

--- a/src/components/remote_control/test/src/rc_module_test.cc
+++ b/src/components/remote_control/test/src/rc_module_test.cc
@@ -41,6 +41,7 @@
 #include "utils/shared_ptr.h"
 #include "utils/make_shared.h"
 #include "application_manager/mock_message_helper.h"
+#include "application_manager/mock_application_manager_settings.h"
 
 using functional_modules::PluginInfo;
 using functional_modules::ProcessResult;
@@ -50,6 +51,8 @@ using application_manager::ServicePtr;
 using application_manager::MockService;
 using application_manager::MockMessageHelper;
 using test::components::application_manager_test::MockApplication;
+using test::components::application_manager_test::
+    MockApplicationManagerSettings;
 
 using ::testing::_;
 using ::testing::Mock;
@@ -67,6 +70,7 @@ namespace {
 const bool kDeviceHandle = 1u;
 const std::string kDeviceId = "1";
 const std::string kDeviceName = "1";
+const uint32_t kDefaultTimeout = 10000;
 }
 
 namespace remote_control {
@@ -75,6 +79,8 @@ class RCModuleTest : public ::testing::Test {
  public:
   RCModuleTest()
       : mock_service_(utils::MakeShared<NiceMock<MockService> >())
+      , mock_settings_(
+            utils::MakeShared<NiceMock<MockApplicationManagerSettings> >())
       , mock_message_helper_(*MockMessageHelper::message_helper_mock())
       , app0_(utils::MakeShared<NiceMock<MockApplication> >())
       , app1_(utils::MakeShared<NiceMock<MockApplication> >())
@@ -90,6 +96,7 @@ class RCModuleTest : public ::testing::Test {
  protected:
   RemoteControlPlugin module_;
   utils::SharedPtr<NiceMock<MockService> > mock_service_;
+  utils::SharedPtr<NiceMock<MockApplicationManagerSettings> > mock_settings_;
   MockMessageHelper& mock_message_helper_;
   std::vector<ApplicationSharedPtr> apps_;
   utils::SharedPtr<NiceMock<MockApplication> > app0_;
@@ -99,6 +106,10 @@ class RCModuleTest : public ::testing::Test {
 
   void SetUp() OVERRIDE {
     Mock::VerifyAndClearExpectations(&mock_message_helper_);
+    ON_CALL(*mock_service_, GetSettings())
+        .WillByDefault(ReturnRef(*mock_settings_));
+    ON_CALL(*mock_settings_, default_timeout())
+        .WillByDefault(ReturnRef(kDefaultTimeout));
     ServicePtr exp_service(mock_service_);
     module_.set_service(exp_service);
     ServicePtr out_service = module_.service();


### PR DESCRIPTION
There was a separate parameter in `smartDeviceLink.ini` file, which specify timeout value for RC requests only. This parameter seems redundant and was replaced with default request timeout from profile.cc 
Also was added missing description for some functions and removed some unused code.