### PR TITLE
Rename Subject struct to ApplicationOnDevice

### DIFF
--- a/src/components/policy/policy_external/include/policy/access_remote.h
+++ b/src/components/policy/policy_external/include/policy/access_remote.h
@@ -58,17 +58,20 @@ inline std::ostream& operator<<(std::ostream& output, TypeAccess x) {
   return output;
 }
 
-struct Subject {
+struct ApplicationOnDevice {
   PTString dev_id;
   PTString app_id;
 };
-inline bool operator<(const Subject& x, const Subject& y) {
+inline bool operator<(const ApplicationOnDevice& x,
+                      const ApplicationOnDevice& y) {
   return x.dev_id < y.dev_id || (x.dev_id == y.dev_id && x.app_id < y.app_id);
 }
-inline bool operator==(const Subject& x, const Subject& y) {
+inline bool operator==(const ApplicationOnDevice& x,
+                       const ApplicationOnDevice& y) {
   return x.dev_id == y.dev_id && x.app_id == y.app_id;
 }
-inline std::ostream& operator<<(std::ostream& output, const Subject& who) {
+inline std::ostream& operator<<(std::ostream& output,
+                                const ApplicationOnDevice& who) {
   output << "Subject(dev:" << who.dev_id << ", app:" << who.app_id << ")";
   return output;
 }
@@ -92,7 +95,7 @@ class AccessRemote {
    * @param who application on specific device
    * @param hmi_types hmi types list
    */
-  virtual void SetDefaultHmiTypes(const Subject& who,
+  virtual void SetDefaultHmiTypes(const ApplicationOnDevice& who,
                                   const std::vector<int>& hmi_types) = 0;
 
   /**
@@ -100,7 +103,8 @@ class AccessRemote {
    * @param who application on specific device
    * @return list of groups
    */
-  virtual const policy_table::Strings& GetGroups(const Subject& who) = 0;
+  virtual const policy_table::Strings& GetGroups(
+      const ApplicationOnDevice& who) = 0;
 
   /**
    * @brief GetPermissionsForApp read list of permissions for application
@@ -118,7 +122,7 @@ class AccessRemote {
    * @param who application on specific device
    * @return true is remote controll aotherwise return false
    */
-  virtual bool IsAppRemoteControl(const Subject& who) = 0;
+  virtual bool IsAppRemoteControl(const ApplicationOnDevice& who) = 0;
 
   /**
    * @brief GetModuleTypes get list of module types of application

--- a/src/components/policy/policy_external/include/policy/access_remote_impl.h
+++ b/src/components/policy/policy_external/include/policy/access_remote_impl.h
@@ -61,7 +61,7 @@ class AccessRemoteImpl : public AccessRemote {
    * @param who application on specific device
    * @param hmi_types hmi types list
    */
-  void SetDefaultHmiTypes(const Subject& who,
+  void SetDefaultHmiTypes(const ApplicationOnDevice& who,
                           const std::vector<int>& hmi_types) OVERRIDE;
 
   /**
@@ -69,7 +69,8 @@ class AccessRemoteImpl : public AccessRemote {
    * @param who application on specific device
    * @return list of groups
    */
-  const policy_table::Strings& GetGroups(const Subject& who) OVERRIDE;
+  const policy_table::Strings& GetGroups(
+      const ApplicationOnDevice& who) OVERRIDE;
 
   /**
    * @brief GetPermissionsForApp read list of permissions for application
@@ -87,7 +88,7 @@ class AccessRemoteImpl : public AccessRemote {
    * @param who application on specific device
    * @return true is remote controll aotherwise return false
    */
-  bool IsAppRemoteControl(const Subject& who) OVERRIDE;
+  bool IsAppRemoteControl(const ApplicationOnDevice& who) OVERRIDE;
 
   /**
    * @brief GetModuleTypes get list of module types of application
@@ -106,7 +107,7 @@ class AccessRemoteImpl : public AccessRemote {
    * @param who  application on specific device
    * @return list of hmi types
    */
-  const policy_table::AppHMITypes& HmiTypes(const Subject& who);
+  const policy_table::AppHMITypes& HmiTypes(const ApplicationOnDevice& who);
 
   /**
    * @brief GetGroupsIds get list of groups for application
@@ -148,7 +149,7 @@ class AccessRemoteImpl : public AccessRemote {
   /**
    * @brief hmi_types_ contains list of default HMI types for applications
    */
-  typedef std::map<Subject, policy_table::AppHMITypes> HMIList;
+  typedef std::map<ApplicationOnDevice, policy_table::AppHMITypes> HMIList;
   HMIList hmi_types_;
 
 #ifdef BUILD_TESTS

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -482,7 +482,7 @@ class PolicyManagerImpl : public PolicyManager {
    * @brief Sends notification about application HMI level changed
    * @param who application information structure
    */
-  void SendHMILevelChanged(const Subject& who);
+  void SendHMILevelChanged(const ApplicationOnDevice& who);
 
   /**
    * @brief Sends notification if application permissions were changed

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -597,7 +597,7 @@ void PolicyManagerImpl::CheckPermissions(const PTString& app_id,
     cache_->GetFunctionalGroupings(functional_groupings);
 
 #ifdef SDL_REMOTE_CONTROL
-    Subject who = {device_id, app_id};
+    ApplicationOnDevice who = {device_id, app_id};
     const policy_table::Strings app_groups = access_remote_->GetGroups(who);
 #else   // SDL_REMOTE_CONTROL
     const policy_table::Strings app_groups =
@@ -782,7 +782,7 @@ void PolicyManagerImpl::SendNotificationOnPermissionsUpdated(
                "Send notification for application_id:" << application_id);
 
 #ifdef SDL_REMOTE_CONTROL
-  const Subject who = {device_id, application_id};
+  const ApplicationOnDevice who = {device_id, application_id};
   if (access_remote_->IsAppRemoteControl(who)) {
     listener()->OnPermissionsUpdated(application_id, notification_data);
     return;
@@ -1937,7 +1937,7 @@ void PolicyManagerImpl::SetDefaultHmiTypes(const std::string& application_id,
                                            const std::vector<int>& hmi_types) {
   LOG4CXX_INFO(logger_, "SetDefaultHmiTypes");
   const std::string device_id = GetCurrentDeviceId(application_id);
-  Subject who = {device_id, application_id};
+  ApplicationOnDevice who = {device_id, application_id};
   access_remote_->SetDefaultHmiTypes(who, hmi_types);
 }
 
@@ -1972,7 +1972,7 @@ bool PolicyManagerImpl::CheckModule(const PTString& app_id,
          access_remote_->CheckModuleType(app_id, module_type);
 }
 
-void PolicyManagerImpl::SendHMILevelChanged(const Subject& who) {
+void PolicyManagerImpl::SendHMILevelChanged(const ApplicationOnDevice& who) {
   std::string default_hmi("NONE");
   if (GetDefaultHmi(who.app_id, &default_hmi)) {
     listener()->OnUpdateHMIStatus(who.dev_id, who.app_id, default_hmi);
@@ -2021,7 +2021,7 @@ void PolicyManagerImpl::OnPrimaryGroupsChanged(
   for (std::vector<std::string>::const_iterator i = devices.begin();
        i != devices.end();
        ++i) {
-    const Subject who = {*i, application_id};
+    const ApplicationOnDevice who = {*i, application_id};
     if (access_remote_->IsAppRemoteControl(who)) {
       SendAppPermissionsChanged(who.dev_id, who.app_id);
     }

--- a/src/components/policy/policy_regular/include/policy/access_remote.h
+++ b/src/components/policy/policy_regular/include/policy/access_remote.h
@@ -41,17 +41,20 @@
 namespace policy_table = ::rpc::policy_table_interface_base;
 
 namespace policy {
-struct Subject {
+struct ApplicationOnDevice {
   PTString dev_id;
   PTString app_id;
 };
-inline bool operator<(const Subject& x, const Subject& y) {
+inline bool operator<(const ApplicationOnDevice& x,
+                      const ApplicationOnDevice& y) {
   return x.dev_id < y.dev_id || (x.dev_id == y.dev_id && x.app_id < y.app_id);
 }
-inline bool operator==(const Subject& x, const Subject& y) {
+inline bool operator==(const ApplicationOnDevice& x,
+                       const ApplicationOnDevice& y) {
   return x.dev_id == y.dev_id && x.app_id == y.app_id;
 }
-inline std::ostream& operator<<(std::ostream& output, const Subject& who) {
+inline std::ostream& operator<<(std::ostream& output,
+                                const ApplicationOnDevice& who) {
   output << "Subject(dev:" << who.dev_id << ", app:" << who.app_id << ")";
   return output;
 }
@@ -75,7 +78,7 @@ class AccessRemote {
    * @param who application on specific device
    * @param hmi_types hmi types list
    */
-  virtual void SetDefaultHmiTypes(const Subject& who,
+  virtual void SetDefaultHmiTypes(const ApplicationOnDevice& who,
                                   const std::vector<int>& hmi_types) = 0;
 
   /**
@@ -83,7 +86,8 @@ class AccessRemote {
    * @param who application on specific device
    * @return list of groups
    */
-  virtual const policy_table::Strings& GetGroups(const Subject& who) = 0;
+  virtual const policy_table::Strings& GetGroups(
+      const ApplicationOnDevice& who) = 0;
 
   /**
    * @brief GetPermissionsForApp read list of permissions for application
@@ -101,7 +105,7 @@ class AccessRemote {
    * @param who application on specific device
    * @return true is remote controll aotherwise return false
    */
-  virtual bool IsAppRemoteControl(const Subject& who) = 0;
+  virtual bool IsAppRemoteControl(const ApplicationOnDevice& who) = 0;
 
   /**
    * @brief GetModuleTypes get list of module types of application

--- a/src/components/policy/policy_regular/include/policy/access_remote_impl.h
+++ b/src/components/policy/policy_regular/include/policy/access_remote_impl.h
@@ -60,14 +60,15 @@ class AccessRemoteImpl : public AccessRemote {
    * @param who application on specific device
    * @param hmi_types hmi types list
    */
-  void SetDefaultHmiTypes(const Subject& who,
+  void SetDefaultHmiTypes(const ApplicationOnDevice& who,
                           const std::vector<int>& hmi_types) OVERRIDE;
   /**
    * @brief GetGroups return list of groups for applicaiton
    * @param who application on specific device
    * @return list of groups
    */
-  const policy_table::Strings& GetGroups(const Subject& who) OVERRIDE;
+  const policy_table::Strings& GetGroups(
+      const ApplicationOnDevice& who) OVERRIDE;
 
   /**
    * @brief GetPermissionsForApp read list of permissions for application
@@ -85,7 +86,7 @@ class AccessRemoteImpl : public AccessRemote {
    * @param who application on specific device
    * @return true is remote controll aotherwise return false
    */
-  bool IsAppRemoteControl(const Subject& who) OVERRIDE;
+  bool IsAppRemoteControl(const ApplicationOnDevice& who) OVERRIDE;
 
   /**
    * @brief GetModuleTypes get list of module types of application
@@ -102,7 +103,7 @@ class AccessRemoteImpl : public AccessRemote {
    * @param who  application on specific device
    * @return list of hmi types
    */
-  const policy_table::AppHMITypes& HmiTypes(const Subject& who);
+  const policy_table::AppHMITypes& HmiTypes(const ApplicationOnDevice& who);
 
   /**
    * @brief GetGroupsIds get list of groups for application
@@ -143,7 +144,7 @@ class AccessRemoteImpl : public AccessRemote {
   /**
    * @brief hmi_types_ contains list of default HMI types for applications
    */
-  typedef std::map<Subject, policy_table::AppHMITypes> HMIList;
+  typedef std::map<ApplicationOnDevice, policy_table::AppHMITypes> HMIList;
   HMIList hmi_types_;
 
 #ifdef BUILD_TESTS

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -476,7 +476,7 @@ class PolicyManagerImpl : public PolicyManager {
    * @brief Sends notification about application HMI level changed
    * @param who application information structure
    */
-  void SendHMILevelChanged(const Subject& who);
+  void SendHMILevelChanged(const ApplicationOnDevice& who);
 
   /**
    * @brief Sends notification if application permissions were changed

--- a/src/components/policy/policy_regular/src/access_remote_impl.cc
+++ b/src/components/policy/policy_regular/src/access_remote_impl.cc
@@ -155,7 +155,7 @@ bool AccessRemoteImpl::CompareParameters(
   return input->empty();
 }
 
-void AccessRemoteImpl::SetDefaultHmiTypes(const Subject& who,
+void AccessRemoteImpl::SetDefaultHmiTypes(const ApplicationOnDevice& who,
                                           const std::vector<int>& hmi_types) {
   LOG4CXX_AUTO_TRACE(logger_);
   HMIList::mapped_type types;
@@ -167,7 +167,7 @@ void AccessRemoteImpl::SetDefaultHmiTypes(const Subject& who,
 }
 
 const policy_table::AppHMITypes& AccessRemoteImpl::HmiTypes(
-    const Subject& who) {
+    const ApplicationOnDevice& who) {
   LOG4CXX_AUTO_TRACE(logger_);
   if (cache_->IsDefaultPolicy(who.app_id)) {
     return hmi_types_[who];
@@ -178,12 +178,13 @@ const policy_table::AppHMITypes& AccessRemoteImpl::HmiTypes(
   }
 }
 
-const policy_table::Strings& AccessRemoteImpl::GetGroups(const Subject& who) {
+const policy_table::Strings& AccessRemoteImpl::GetGroups(
+    const ApplicationOnDevice& who) {
   LOG4CXX_AUTO_TRACE(logger_);
   return cache_->GetGroups(who.app_id);
 }
 
-bool AccessRemoteImpl::IsAppRemoteControl(const Subject& who) {
+bool AccessRemoteImpl::IsAppRemoteControl(const ApplicationOnDevice& who) {
   LOG4CXX_AUTO_TRACE(logger_);
   const policy_table::AppHMITypes& hmi_types = HmiTypes(who);
   return std::find(hmi_types.begin(),
@@ -213,7 +214,7 @@ std::ostream& operator<<(std::ostream& output,
 void AccessRemoteImpl::GetGroupsIds(const std::string& device_id,
                                     const std::string& app_id,
                                     FunctionalGroupIDs& groups_ids) {
-  Subject who = {device_id, app_id};
+  ApplicationOnDevice who = {device_id, app_id};
   const policy_table::Strings& groups = GetGroups(who);
   groups_ids.resize(groups.size());
   std::transform(groups.begin(),

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -395,7 +395,7 @@ void PolicyManagerImpl::CheckPermissions(const PTString& device_id,
                                        << " for " << hmi_level << " level.");
 
 #ifdef SDL_REMOTE_CONTROL
-  Subject who = {device_id, app_id};
+  ApplicationOnDevice who = {device_id, app_id};
   const policy_table::Strings& groups = access_remote_->GetGroups(who);
 #else   // SDL_REMOTE_CONTROL
   const policy_table::Strings& groups = cache_->GetGroups(app_id);
@@ -458,7 +458,7 @@ void PolicyManagerImpl::SendNotificationOnPermissionsUpdated(
   default_hmi = "NONE";
 
 #ifdef SDL_REMOTE_CONTROL
-  const Subject who = {device_id, application_id};
+  const ApplicationOnDevice who = {device_id, application_id};
   if (access_remote_->IsAppRemoteControl(who)) {
     listener()->OnPermissionsUpdated(application_id, notification_data);
     return;
@@ -1169,7 +1169,7 @@ void PolicyManagerImpl::SetDefaultHmiTypes(const std::string& application_id,
                                            const std::vector<int>& hmi_types) {
   LOG4CXX_INFO(logger_, "SetDefaultHmiTypes");
   const std::string device_id = GetCurrentDeviceId(application_id);
-  Subject who = {device_id, application_id};
+  ApplicationOnDevice who = {device_id, application_id};
   access_remote_->SetDefaultHmiTypes(who, hmi_types);
 }
 
@@ -1204,7 +1204,7 @@ bool PolicyManagerImpl::CheckModule(const PTString& app_id,
          access_remote_->CheckModuleType(app_id, module_type);
 }
 
-void PolicyManagerImpl::SendHMILevelChanged(const Subject& who) {
+void PolicyManagerImpl::SendHMILevelChanged(const ApplicationOnDevice& who) {
   std::string default_hmi("NONE");
   if (GetDefaultHmi(who.app_id, &default_hmi)) {
     listener()->OnUpdateHMIStatus(who.dev_id, who.app_id, default_hmi);
@@ -1253,7 +1253,7 @@ void PolicyManagerImpl::OnPrimaryGroupsChanged(
   for (std::vector<std::string>::const_iterator i = devices.begin();
        i != devices.end();
        ++i) {
-    const Subject who = {*i, application_id};
+    const ApplicationOnDevice who = {*i, application_id};
     if (access_remote_->IsAppRemoteControl(who)) {
       SendAppPermissionsChanged(who.dev_id, who.app_id);
     }

--- a/src/components/policy/policy_regular/test/access_remote_impl_test.cc
+++ b/src/components/policy/policy_regular/test/access_remote_impl_test.cc
@@ -66,7 +66,7 @@ TEST(AccessRemoteImplTest, SetDefaultHmiTypes) {
   std::vector<int> hmi_expected;
   hmi_expected.push_back(2);
   hmi_expected.push_back(6);
-  Subject who = {"dev1", "1234"};
+  ApplicationOnDevice who = {"dev1", "1234"};
   access_remote.SetDefaultHmiTypes(who, hmi_expected);
 
   EXPECT_NE(access_remote.hmi_types_.end(), access_remote.hmi_types_.find(who));
@@ -78,7 +78,7 @@ TEST(AccessRemoteImplTest, SetDefaultHmiTypes) {
 
 TEST(AccessRemoteImplTest, GetGroups) {
   AccessRemoteImpl access_remote;
-  Subject who = {"dev1", "1234"};
+  ApplicationOnDevice who = {"dev1", "1234"};
   access_remote.hmi_types_[who].push_back(policy_table::AHT_REMOTE_CONTROL);
 
   access_remote.cache_->pt_ = new policy_table::Table();

--- a/src/components/policy/policy_regular/test/include/policy/mock_access_remote.h
+++ b/src/components/policy/policy_regular/test/include/policy/mock_access_remote.h
@@ -39,7 +39,7 @@ namespace test {
 namespace components {
 namespace access_remote_test {
 
-class MockSubject : public policy::Subject {
+class MockSubject : public policy::ApplicationOnDevice {
  public:
 };
 
@@ -47,14 +47,15 @@ class MockAccessRemote : public policy::AccessRemote {
  public:
   MOCK_CONST_METHOD3(
       FindGroup,
-      policy::PTString(const policy::Subject& who,
+      policy::PTString(const policy::ApplicationOnDevice& who,
                        const policy::PTString& rpc,
                        const policy::RemoteControlParams& params));
   MOCK_METHOD2(SetDefaultHmiTypes,
-               void(const policy::Subject& who,
+               void(const policy::ApplicationOnDevice& who,
                     const std::vector<int>& hmi_types));
-  MOCK_METHOD1(GetGroups,
-               const policy_table::Strings&(const policy::Subject& who));
+  MOCK_METHOD1(
+      GetGroups,
+      const policy_table::Strings&(const policy::ApplicationOnDevice& who));
   MOCK_METHOD3(GetPermissionsForApp,
                bool(const std::string& device_id,
                     const std::string& app_id,
@@ -62,7 +63,8 @@ class MockAccessRemote : public policy::AccessRemote {
   MOCK_CONST_METHOD2(CheckModuleType,
                      bool(const policy::PTString& app_id,
                           policy_table::ModuleType module));
-  MOCK_METHOD1(IsAppRemoteControl, bool(const policy::Subject& who));
+  MOCK_METHOD1(IsAppRemoteControl,
+               bool(const policy::ApplicationOnDevice& who));
   MOCK_METHOD2(GetModuleTypes,
                bool(const std::string& application_id,
                     std::vector<std::string>* modules));


### PR DESCRIPTION
Subject struct was renamed to more descriptive name.

# NOTE
Please review only last 2 commits (32b101dc73529915df153668faf62d33ac2c5c50 and 63b4324752e164442f3b9b15f6a6c4d64bb50708).
Because of dependency from #253 this PR also contains commits from there and should be rebased after related PR.