### PR TITLE
Fix SDL build with EXTERNAL_PROPRIETARY flag

### DIFF
--- a/src/components/policy/policy_external/src/access_remote_impl.cc
+++ b/src/components/policy/policy_external/src/access_remote_impl.cc
@@ -155,7 +155,7 @@ bool AccessRemoteImpl::CompareParameters(
   return input->empty();
 }
 
-void AccessRemoteImpl::SetDefaultHmiTypes(const Subject& who,
+void AccessRemoteImpl::SetDefaultHmiTypes(const ApplicationOnDevice& who,
                                           const std::vector<int>& hmi_types) {
   LOG4CXX_AUTO_TRACE(logger_);
   HMIList::mapped_type types;


### PR DESCRIPTION
There was missed one function where `Subject` structure was not renamed so this fails SDL build with this policy flow.