### PR TITLE
Fix build with RC=ON, EXTERNAL_PROPRIETARY, and BUILD_TESTS=ON

### DIFF
--- a/src/components/application_manager/test/message_helper/CMakeLists.txt
+++ b/src/components/application_manager/test/message_helper/CMakeLists.txt
@@ -37,6 +37,7 @@ include_directories(
 
 set(LIBRARIES
     gmock
+    FunctionalModule
     ApplicationManager
     MessageHelper
     jsoncpp


### PR DESCRIPTION
Add Functional module dependency for message_helper test.
Fix build with RC=ON, EXTERNAL_PROPRIETARY, and BUILD_TESTS=ON 