### PR TITLE
Fix response for RC requests from apps without RC HMI type

### DIFF
--- a/src/components/remote_control/src/commands/base_command_request.cc
+++ b/src/components/remote_control/src/commands/base_command_request.cc
@@ -348,6 +348,12 @@ bool BaseCommandRequest::CheckPolicyPermissions() {
     return false;
   }
 
+  if (!service_->IsRemoteControlApplication(app_)) {
+    LOG4CXX_WARN(logger_, "Application has no remote control functions");
+    SendResponse(false, result_codes::kDisallowed, "");
+    return false;
+  }
+
   mobile_apis::Result::eType ret = service_->CheckPolicyPermissions(message_);
   if (ret != mobile_apis::Result::eType::SUCCESS) {
     LOG4CXX_WARN(logger_,

--- a/src/components/remote_control/test/commands/button_press_request_test.cc
+++ b/src/components/remote_control/test/commands/button_press_request_test.cc
@@ -148,6 +148,8 @@ class ButtonPressRequestTest : public ::testing::Test {
         .WillByDefault(Return(&rc_capabilities_));
     ON_CALL(*mock_service_, IsInterfaceAvailable(_))
         .WillByDefault(Return(true));
+    ON_CALL(*mock_service_, IsRemoteControlApplication(_))
+        .WillByDefault(Return(true));
   }
 
   remote_control::request_controller::MobileRequestPtr CreateCommand(

--- a/src/components/remote_control/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/remote_control/test/commands/get_interior_vehicle_data_request_test.cc
@@ -115,6 +115,8 @@ class GetInteriorVehicleDataRequestTest : public ::testing::Test {
         .WillByDefault(Return(mock_app_));
     ON_CALL(*mock_service_, IsInterfaceAvailable(_))
         .WillByDefault(Return(true));
+    ON_CALL(*mock_service_, IsRemoteControlApplication(_))
+        .WillByDefault(Return(true));
     EXPECT_CALL(mock_module_, event_dispatcher())
         .WillRepeatedly(ReturnRef(event_dispatcher_));
     ServicePtr exp_service(mock_service_);

--- a/src/components/remote_control/test/commands/on_remote_control_settings_test.cc
+++ b/src/components/remote_control/test/commands/on_remote_control_settings_test.cc
@@ -106,6 +106,8 @@ class OnRemoteControlSettingsNotificationTest : public ::testing::Test {
         .WillByDefault(ReturnRef(mock_allocation_manager_));
     ON_CALL(*mock_service_, IsInterfaceAvailable(_))
         .WillByDefault(Return(true));
+    ON_CALL(*mock_service_, IsRemoteControlApplication(_))
+        .WillByDefault(Return(true));
     apps_.push_back(mock_app_);
   }
 

--- a/src/components/remote_control/test/commands/set_interior_vehicle_data_request_test.cc
+++ b/src/components/remote_control/test/commands/set_interior_vehicle_data_request_test.cc
@@ -124,6 +124,8 @@ class SetInteriorVehicleDataRequestTest : public ::testing::Test {
     ON_CALL(*mock_service_, GetApplication(_)).WillByDefault(Return(mock_app_));
     ON_CALL(*mock_service_, IsInterfaceAvailable(_))
         .WillByDefault(Return(true));
+    ON_CALL(*mock_service_, IsRemoteControlApplication(_))
+        .WillByDefault(Return(true));
     ON_CALL(mock_module_, event_dispatcher())
         .WillByDefault(ReturnRef(event_dispatcher_));
     ServicePtr exp_service(mock_service_);


### PR DESCRIPTION
There was no checks that application, which sends RC RPCs, has `REMOTE_CONTROL` type, therefore SDL was successfully processed RPCs from such applications.

Was added check into `BaseCommandRequest::CheckPolicyPermissions()` to fix such situation.