### PR TITLE
fix of non getting NONE by OnRemoteControlSettings(false)

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1605,6 +1605,19 @@ void ApplicationManagerImpl::SendMessageToMobile(
         msg_to_mobile[strings::params][strings::correlation_id].asUInt(),
         msg_to_mobile[strings::params][strings::connection_key].asUInt(),
         msg_to_mobile[strings::params][strings::function_id].asInt());
+#ifdef SDL_REMOTE_CONTROL
+    const mobile_apis::FunctionID::eType function_id =
+      static_cast<mobile_apis::FunctionID::eType>(
+          (*message)[strings::params][strings::function_id].asUInt());
+    if (function_id == mobile_apis::FunctionID::RegisterAppInterfaceID &&
+        (*message)[strings::msg_params][strings::success].asBool()) {
+      const bool is_for_plugin = plugin_manager_.IsAppForPlugins(app);
+      LOG4CXX_INFO(logger_,
+                   "Registered app " << app->app_id() << " is "
+                                     << (is_for_plugin ? "" : "not ")
+                                     << "for plugins.");
+    }
+#endif  // SDL_REMOTE_CONTROL
   } else if (app) {
     mobile_apis::FunctionID::eType function_id =
         static_cast<mobile_apis::FunctionID::eType>(


### PR DESCRIPTION
this is a fix of issue when SDL doesn't set NONE for REMOTE_CONTROL App by OnInteriorVehicleData(false)

**Preconditions:**
1. Make sure SDL is built with PROPRIETARY flag
2. Start SDL and HMI, first ignition cycle
3. Connect device
4. Register applications
App1: REMOTE_CONTROL
App2: REMOTE_CONTROL
App3:DEFAULT

**Steps:**
1. Activate applications
2. HMI-SDL: OnRemoteControlSettings (allowed:false)
3. Check OnHMIStatus notification for each application

**Expected result:**
SDL->App1: OnHMIStatus (NONE)
SDL->App2: OnHMIStatus (NONE)
ADL->App3: do not send OnHMIStatus

**Actual result:**
SDL->App1: OnHMIStatus is not sent - NOK
SDL->App2: OnHMIStatus is not sent - NOK
ADL->App3: OnHMIStatus is not sent - OK

_The fix actually is restore removed RC related code during registration_